### PR TITLE
Migrate to Third Coast 21.3.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id "java"
     id "edu.wpi.first.GradleRIO" version "2021.2.1"
-    id "org.jetbrains.kotlin.jvm" version "1.3.50"
+    id "org.jetbrains.kotlin.jvm" version "1.5.20"
     id "idea"
     id "com.diffplug.gradle.spotless" version "3.24.2"
 }
@@ -83,8 +83,7 @@ dependencies {
 
 compileKotlin{
     kotlinOptions{
-        jvmTarget = "1.8"
-        freeCompilerArgs = ["-progressive"]
+        jvmTarget = "11"
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=permwrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.0.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.9-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=permwrapper/dists

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -67,73 +67,24 @@ public final class Constants {
     }
   }
 
-  //
-  // These settings are temporarily moved here from the DriveSubsystem to facilitate copying them
-  // into the DriveConstants below
-  //
-  //  private static final double ROBOT_LENGTH = 25.5;
-  //  private static final double ROBOT_WIDTH = 21.5;
-  //  private static final double DRIVE_SETPOINT_MAX = 18000.0;
-  //  private static final int XLOCK_FL_TICKS_TARGET = 567;
-  //  private static final int XLOCK_FR_TICKS_TARGET = 1481;
-  //  private static final int AZIMUTH_TICKS = 4096;
-  //  private static final double MAX_VELOCITY = 40000; // FIXME
-  //  private static final double MAX_ACCELERATION = 2.0; // FIXME
-  //  private static final int TICKS_PER_REV = 9011; // FIXME
-  //  private static final double WHEEL_DIAMETER = 0.0635; // In meters
-  //  private static final double TICKS_PER_METER = 55451; // TICKS_PER_REV / (WHEEL_DIAMETER *
-  // Math.PI)
-  //  private static final double kP_PATH = 10; // FIXME?
-  //  private static final double MAX_VELOCITY_MPS = (MAX_VELOCITY * 10) / TICKS_PER_METER;
-  //  private static final double kV_PATH = 1 / MAX_VELOCITY_MPS;
-  //  private static final double kP_YAW = 0.01;
-
-  //  TalonSRXConfiguration azimuthConfig = new TalonSRXConfiguration();
-  //  azimuthConfig.primaryPID.selectedFeedbackSensor = FeedbackDevice.CTRE_MagEncoder_Relative;
-  //  azimuthConfig.continuousCurrentLimit = 10;
-  //  azimuthConfig.peakCurrentDuration = 0;
-  //  azimuthConfig.peakCurrentLimit = 0;
-  //  azimuthConfig.slot0.kP = 10.0;
-  //  azimuthConfig.slot0.kI = 0.0;
-  //  azimuthConfig.slot0.kD = 100.0;
-  //  azimuthConfig.slot0.kF = 0.0;
-  //  azimuthConfig.slot0.integralZone = 0;
-  //  azimuthConfig.slot0.allowableClosedloopError = 0;
-  //  azimuthConfig.motionAcceleration = 10_000;
-  //  azimuthConfig.motionCruiseVelocity = 800;
-  //  azimuthConfig.velocityMeasurementWindow = 64;
-  //  azimuthConfig.voltageCompSaturation = 12;
-  //
-  //  TalonFXConfiguration driveConfig = new TalonFXConfiguration();
-  //  driveConfig.supplyCurrLimit.currentLimit = 0.04;
-  //  driveConfig.supplyCurrLimit.triggerThresholdCurrent = 45;
-  //  driveConfig.supplyCurrLimit.triggerThresholdTime = 40;
-  //  driveConfig.supplyCurrLimit.enable = true;
-  //  driveConfig.slot0.kP = 0.045;
-  //  driveConfig.slot0.kI = 0.0005;
-  //  driveConfig.slot0.kD = 0.000;
-  //  driveConfig.slot0.kF = 0.047;
-  //  driveConfig.slot0.integralZone = 500;
-  //  driveConfig.slot0.maxIntegralAccumulator = 75_000;
-  //  driveConfig.slot0.allowableClosedloopError = 0;
-  //  driveConfig.velocityMeasurementPeriod = VelocityMeasPeriod.Period_100Ms;
-  //  driveConfig.velocityMeasurementWindow = 64;
-  //  driveConfig.voltageCompSaturation = 12;
-
   public static final class DriveConstants {
 
     public static final double kDeadbandXLock = 0.2;
 
-    // TODO: get real measurements
-    public static final double kWheelDiameterInches = 3.0 * (508.0 / 504.0);
-    public static final double kMaxSpeedMetersPerSecond = 3.53568;
+    // TODO: verify diameter and run calibration
+    // 500 cm calibration = actual / odometry
+    public static final double kWheelDiameterInches = 2.5 * (500.0 / 500.0);
+
+    // From: https://github.com/strykeforce/axis-config/
+    public static final double kMaxSpeedMetersPerSecond = 3.889;
+
     public static final double kMaxOmega =
-        (kMaxSpeedMetersPerSecond / Math.hypot(0.525 / 2.0, 0.765 / 2.0))
+        (kMaxSpeedMetersPerSecond / Math.hypot(0.5461 / 2.0, 0.6477 / 2.0))
             / 2.0; // wheel locations below
 
-    // TODO: get real measurements
-    static final double kDriveMotorOutputGear = 25;
-    static final double kDriveInputGear = 44;
+    // From: https://github.com/strykeforce/axis-config/
+    static final double kDriveMotorOutputGear = 22;
+    static final double kDriveInputGear = 48;
     static final double kBevelInputGear = 15;
     static final double kBevelOutputGear = 45;
     public static final double kDriveGearRatio =
@@ -144,9 +95,8 @@ public final class Constants {
     }
 
     public static Translation2d[] getWheelLocationMeters() {
-      // TODO: get real measurements
-      final double x = 0.525 / 2.0; // front-back
-      final double y = 0.765 / 2.0; // left-right
+      final double x = 0.5461 / 2.0; // front-back, was ROBOT_LENGTH
+      final double y = 0.6477 / 2.0; // left-right, was ROBOT_WIDTH
       Translation2d[] locs = new Translation2d[4];
       locs[0] = new Translation2d(x, y); // left front
       locs[1] = new Translation2d(x, -y); // right front
@@ -155,7 +105,6 @@ public final class Constants {
       return locs;
     }
 
-    // TODO: get real azimuth settings
     public static TalonSRXConfiguration getAzimuthTalonConfig() {
       // constructor sets encoder to Quad/CTRE_MagEncoder_Relative
       TalonSRXConfiguration azimuthConfig = new TalonSRXConfiguration();
@@ -167,15 +116,15 @@ public final class Constants {
       azimuthConfig.reverseLimitSwitchSource = LimitSwitchSource.Deactivated;
 
       azimuthConfig.continuousCurrentLimit = 10;
-      azimuthConfig.peakCurrentDuration = 1;
-      azimuthConfig.peakCurrentLimit = 1;
+      azimuthConfig.peakCurrentDuration = 0;
+      azimuthConfig.peakCurrentLimit = 0;
       azimuthConfig.slot0.kP = 10.0;
       azimuthConfig.slot0.kI = 0.0;
       azimuthConfig.slot0.kD = 100.0;
-      azimuthConfig.slot0.kF = 1.0;
+      azimuthConfig.slot0.kF = 0.0;
       azimuthConfig.slot0.integralZone = 0;
       azimuthConfig.slot0.allowableClosedloopError = 0;
-      azimuthConfig.slot0.maxIntegralAccumulator = 10;
+      azimuthConfig.slot0.maxIntegralAccumulator = 0;
       azimuthConfig.motionCruiseVelocity = 800;
       azimuthConfig.motionAcceleration = 10_000;
       azimuthConfig.velocityMeasurementWindow = 64;
@@ -183,7 +132,6 @@ public final class Constants {
       return azimuthConfig;
     }
 
-    // TODO: get real drive settings
     public static TalonFXConfiguration getDriveTalonConfig() {
       TalonFXConfiguration driveConfig = new TalonFXConfiguration();
       driveConfig.supplyCurrLimit.currentLimit = 0.04;

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -73,7 +73,7 @@ public final class Constants {
 
     // TODO: verify diameter and run calibration
     // 500 cm calibration = actual / odometry
-    public static final double kWheelDiameterInches = 2.5 * (500.0 / 500.0);
+    public static final double kWheelDiameterInches = 3.0 * (500.0 / 500.0);
 
     // From: https://github.com/strykeforce/axis-config/
     public static final double kMaxSpeedMetersPerSecond = 3.889;
@@ -271,8 +271,9 @@ public final class Constants {
     public static final int kTableRes = 1;
     public static final int kShooterIndex = 2;
     public static final int kHoodIndex = 3;
-    public static final double kHorizAngleCorrection = 0;
-    // + is further and lower
+    // + is left
+    public static final double kHorizAngleCorrection = 3;
+    // + is further along track and lower
     public static final int kHoodInchesCorrectionR1 = 0; // 8-15 feet
     public static final int kHoodInchesCorrectionR2 = 0; // 15-19 feet
     public static final int kHoodInchesCorrectionR3 = 0; // 19-25 feet
@@ -296,7 +297,7 @@ public final class Constants {
     // Turret
     public static final int kTurretZeroTicks = 1931;
     public static final double kMaxStringPotZero = 100;
-    public static final double kMinStringPotZero = 35;
+    public static final double kMinStringPotZero = 0;
 
     // Hood
     public static final int kHoodZeroTicks = 2008; // gut check: 162

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -36,7 +36,6 @@ public class Robot extends TimedRobot {
     // Instantiate our RobotContainer.  This will perform all our button bindings, and put our
     // autonomous chooser on the dashboard.
     m_robotContainer = new RobotContainer();
-    RobotContainer.DRIVE.zeroGyro();
     RobotContainer.HOOD.zeroHood();
     RobotContainer.TURRET.zeroTurret();
     RobotContainer.CLIMBER.zeroClimb();

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -17,8 +17,8 @@ import frc.robot.controls.AutoChooser;
 import frc.robot.controls.Controls;
 import frc.robot.subsystems.*;
 import org.strykeforce.deadeye.Deadeye;
-import org.strykeforce.thirdcoast.telemetry.TelemetryController;
-import org.strykeforce.thirdcoast.telemetry.TelemetryService;
+import org.strykeforce.telemetry.TelemetryController;
+import org.strykeforce.telemetry.TelemetryService;
 
 /**
  * This class is where the bulk of the robot should be declared. Since Command-based is a

--- a/src/main/java/frc/robot/commands/auto/PathDriveCommand.java
+++ b/src/main/java/frc/robot/commands/auto/PathDriveCommand.java
@@ -1,6 +1,5 @@
 package frc.robot.commands.auto;
 
-import edu.wpi.first.wpilibj.Timer;
 import edu.wpi.first.wpilibj.trajectory.Trajectory;
 import edu.wpi.first.wpilibj2.command.CommandBase;
 import frc.robot.RobotContainer;
@@ -20,41 +19,47 @@ public class PathDriveCommand extends CommandBase {
 
   public PathDriveCommand(String trajectoryName, double targetYaw) {
     addRequirements(driveSubsystem);
-    trajectory = driveSubsystem.calculateTrajectory(trajectoryName);
+    // TODO: convert to new trajectory
+    //    trajectory = driveSubsystem.calculateTrajectory(trajectoryName);
     this.targetYaw = targetYaw;
   }
 
   @Override
   public void initialize() {
-    isFirstExecute = true;
-    driveSubsystem.offsetGyro(-targetYaw);
-    driveSubsystem.startPath(trajectory, targetYaw);
-    logger.info("Starting pathing...");
+    // TODO: convert to new trajectory
+    //    isFirstExecute = true;
+    //    driveSubsystem.offsetGyro(-targetYaw);
+    //    driveSubsystem.startPath(trajectory, targetYaw);
+    //    logger.info("Starting pathing...");
   }
 
   @Override
   public void execute() {
-    if (isFirstExecute) {
-      startTimeSeconds = Timer.getFPGATimestamp();
-      isFirstExecute = false;
-    }
-    double currentTimeSeconds = Timer.getFPGATimestamp();
-    timeElapsed = currentTimeSeconds - startTimeSeconds;
+    // TODO: convert to new trajectory
+    //    if (isFirstExecute) {
+    //      startTimeSeconds = Timer.getFPGATimestamp();
+    //      isFirstExecute = false;
+    //    }
+    //    double currentTimeSeconds = Timer.getFPGATimestamp();
+    //    timeElapsed = currentTimeSeconds - startTimeSeconds;
     //    logger.info("Current time seconds: " + timeElapsed);
-    driveSubsystem.updatePathOutput(timeElapsed);
+    //    driveSubsystem.updatePathOutput(timeElapsed);
   }
 
   @Override
   public boolean isFinished() {
-    return driveSubsystem.isPathDone(timeElapsed);
+    return true;
+    // TODO: convert to new trajectory
+    //    return driveSubsystem.isPathDone(timeElapsed);
   }
 
   @Override
   public void end(boolean interrupted) {
-    logger.info("Stopping pathing; Interruption: " + interrupted);
-    driveSubsystem.offsetGyro(targetYaw);
-    driveSubsystem.drive(0, 0, 0);
-    driveSubsystem.offsetGyro(targetYaw);
+    // TODO: convert to new trajectory
+    //    logger.info("Stopping pathing; Interruption: " + interrupted);
+    //    driveSubsystem.offsetGyro(targetYaw);
+    //    driveSubsystem.drive(0, 0, 0);
+    //    driveSubsystem.offsetGyro(targetYaw);
     //    driveSubsystem.setDriveMode(DriveMode.OPEN_LOOP);
   }
 }

--- a/src/main/java/frc/robot/commands/auto/PathDriveCommand.java
+++ b/src/main/java/frc/robot/commands/auto/PathDriveCommand.java
@@ -7,7 +7,6 @@ import frc.robot.RobotContainer;
 import frc.robot.subsystems.DriveSubsystem;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.strykeforce.thirdcoast.swerve.SwerveDrive.DriveMode;
 
 public class PathDriveCommand extends CommandBase {
 
@@ -56,6 +55,6 @@ public class PathDriveCommand extends CommandBase {
     driveSubsystem.offsetGyro(targetYaw);
     driveSubsystem.drive(0, 0, 0);
     driveSubsystem.offsetGyro(targetYaw);
-    driveSubsystem.setDriveMode(DriveMode.OPEN_LOOP);
+    //    driveSubsystem.setDriveMode(DriveMode.OPEN_LOOP);
   }
 }

--- a/src/main/java/frc/robot/commands/drive/DistanceCalibrateCommand.java
+++ b/src/main/java/frc/robot/commands/drive/DistanceCalibrateCommand.java
@@ -8,11 +8,11 @@ import org.slf4j.LoggerFactory;
 
 public class DistanceCalibrateCommand extends CommandBase {
 
+  private final Logger logger = LoggerFactory.getLogger(this.getClass());
   private DriveSubsystem driveSubsystem = RobotContainer.DRIVE;
   private double[] currentEncoder = new double[4];
   private double[] beginningEncoder = new double[4];
   private int ticks = 0;
-  private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
   public DistanceCalibrateCommand(int ticks) {
 
@@ -23,8 +23,8 @@ public class DistanceCalibrateCommand extends CommandBase {
   @Override
   public void initialize() {
     for (int i = 0; i < 4; i++) {
-      beginningEncoder[i] =
-          driveSubsystem.getAllWheels()[i].getDriveTalon().getSelectedSensorPosition();
+      //      beginningEncoder[i] =
+      //          driveSubsystem.getAllWheels()[i].getDriveTalon().getSelectedSensorPosition();
     }
     driveSubsystem.drive(0.25, 0, 0);
   }
@@ -36,8 +36,8 @@ public class DistanceCalibrateCommand extends CommandBase {
   public void end(boolean interrupted) {
     double[] deltaEncoder = new double[4];
     for (int i = 0; i < 4; i++) {
-      currentEncoder[i] =
-          driveSubsystem.getAllWheels()[i].getDriveTalon().getSelectedSensorPosition();
+      //      currentEncoder[i] =
+      //          driveSubsystem.getAllWheels()[i].getDriveTalon().getSelectedSensorPosition();
       deltaEncoder[i] = Math.abs(currentEncoder[i] - beginningEncoder[i]);
     }
     driveSubsystem.drive(0, 0, 0);
@@ -51,10 +51,10 @@ public class DistanceCalibrateCommand extends CommandBase {
 
   @Override
   public boolean isFinished() {
-
-    return Math.abs(
-            driveSubsystem.getAllWheels()[1].getDriveTalon().getSelectedSensorPosition()
-                - beginningEncoder[1])
-        >= ticks;
+    return true;
+    //    return Math.abs(
+    //            driveSubsystem.getAllWheels()[1].getDriveTalon().getSelectedSensorPosition()
+    //                - beginningEncoder[1])
+    //        >= ticks;
   }
 }

--- a/src/main/java/frc/robot/commands/drive/DistanceCalibrateCommand.java
+++ b/src/main/java/frc/robot/commands/drive/DistanceCalibrateCommand.java
@@ -22,11 +22,12 @@ public class DistanceCalibrateCommand extends CommandBase {
 
   @Override
   public void initialize() {
-    for (int i = 0; i < 4; i++) {
-      //      beginningEncoder[i] =
-      //          driveSubsystem.getAllWheels()[i].getDriveTalon().getSelectedSensorPosition();
-    }
-    driveSubsystem.drive(0.25, 0, 0);
+    // TODO: convert to new swerve
+    //    for (int i = 0; i < 4; i++) {
+    //      beginningEncoder[i] =
+    //          driveSubsystem.getAllWheels()[i].getDriveTalon().getSelectedSensorPosition();
+    //    }
+    //    driveSubsystem.drive(0.25, 0, 0);
   }
 
   @Override
@@ -34,24 +35,26 @@ public class DistanceCalibrateCommand extends CommandBase {
 
   @Override
   public void end(boolean interrupted) {
-    double[] deltaEncoder = new double[4];
-    for (int i = 0; i < 4; i++) {
-      //      currentEncoder[i] =
-      //          driveSubsystem.getAllWheels()[i].getDriveTalon().getSelectedSensorPosition();
-      deltaEncoder[i] = Math.abs(currentEncoder[i] - beginningEncoder[i]);
-    }
-    driveSubsystem.drive(0, 0, 0);
-    logger.info(
-        "Delta Ticks, {}, {}, {}, {}, ",
-        deltaEncoder[0],
-        deltaEncoder[1],
-        deltaEncoder[2],
-        deltaEncoder[3]);
+    // TODO: convert to new swerve
+    //    double[] deltaEncoder = new double[4];
+    //    for (int i = 0; i < 4; i++) {
+    //      currentEncoder[i] =
+    //          driveSubsystem.getAllWheels()[i].getDriveTalon().getSelectedSensorPosition();
+    //      deltaEncoder[i] = Math.abs(currentEncoder[i] - beginningEncoder[i]);
+    //    }
+    //    driveSubsystem.drive(0, 0, 0);
+    //    logger.info(
+    //        "Delta Ticks, {}, {}, {}, {}, ",
+    //        deltaEncoder[0],
+    //        deltaEncoder[1],
+    //        deltaEncoder[2],
+    //        deltaEncoder[3]);
   }
 
   @Override
   public boolean isFinished() {
     return true;
+    // TODO: convert to new swerve
     //    return Math.abs(
     //            driveSubsystem.getAllWheels()[1].getDriveTalon().getSelectedSensorPosition()
     //                - beginningEncoder[1])

--- a/src/main/java/frc/robot/commands/drive/OffsetGyroCommand.java
+++ b/src/main/java/frc/robot/commands/drive/OffsetGyroCommand.java
@@ -15,6 +15,7 @@ public class OffsetGyroCommand extends InstantCommand {
 
   @Override
   public void initialize() {
-    DRIVE.offsetGyro(offset);
+    // TODO: convert to new swerve
+    //    DRIVE.offsetGyro(offset);
   }
 }

--- a/src/main/java/frc/robot/commands/drive/TeleopDriveCommand.java
+++ b/src/main/java/frc/robot/commands/drive/TeleopDriveCommand.java
@@ -1,6 +1,7 @@
 package frc.robot.commands.drive;
 
 import edu.wpi.first.wpilibj2.command.CommandBase;
+import frc.robot.Constants;
 import frc.robot.RobotContainer;
 import frc.robot.controls.DriverControls;
 import frc.robot.subsystems.DriveSubsystem;
@@ -35,8 +36,11 @@ public class TeleopDriveCommand extends CommandBase {
     double forward = forwardScale.apply(driverControls.getForward());
     double strafe = strafeScale.apply(driverControls.getStrafe());
     double yaw = yawScale.apply(driverControls.getYaw());
+    double vx = forward * -Constants.DriveConstants.kMaxSpeedMetersPerSecond;
+    double vy = strafe * Constants.DriveConstants.kMaxSpeedMetersPerSecond;
+    double omega = yaw * Constants.DriveConstants.kMaxOmega;
 
-    DRIVE.drive(-forward, -strafe, -yaw);
+    DRIVE.drive(vx, vy, omega);
   }
 
   @Override

--- a/src/main/java/frc/robot/commands/drive/ZeroDriveWheelsCommand.java
+++ b/src/main/java/frc/robot/commands/drive/ZeroDriveWheelsCommand.java
@@ -13,6 +13,7 @@ public class ZeroDriveWheelsCommand extends InstantCommand {
 
   @Override
   public void initialize() {
-    driveSubsystem.zeroSwerve();
+    // TODO: convert to new swerve
+    //    driveSubsystem.zeroSwerve();
   }
 }

--- a/src/main/java/frc/robot/commands/drive/ZeroGyroCommand.java
+++ b/src/main/java/frc/robot/commands/drive/ZeroGyroCommand.java
@@ -13,7 +13,6 @@ public class ZeroGyroCommand extends InstantCommand {
 
   @Override
   public void initialize() {
-    // TODO: convert to DRIVE.resetGyro()
-    //    DRIVE.zeroGyro();
+    DRIVE.resetGyro();
   }
 }

--- a/src/main/java/frc/robot/commands/drive/ZeroGyroCommand.java
+++ b/src/main/java/frc/robot/commands/drive/ZeroGyroCommand.java
@@ -13,6 +13,7 @@ public class ZeroGyroCommand extends InstantCommand {
 
   @Override
   public void initialize() {
-    DRIVE.zeroGyro();
+    // TODO: convert to DRIVE.resetGyro()
+    //    DRIVE.zeroGyro();
   }
 }

--- a/src/main/java/frc/robot/commands/magazine/LimitMagazineCommand.java
+++ b/src/main/java/frc/robot/commands/magazine/LimitMagazineCommand.java
@@ -10,7 +10,6 @@ import org.slf4j.LoggerFactory;
 
 public class LimitMagazineCommand extends CommandBase {
   private MagazineSubsystem magazineSubsystem = RobotContainer.MAGAZINE;
-  private ShooterSubsystem shooterSubsystem = RobotContainer.SHOOTER;
   private HoodSubsystem hoodSubsystem = RobotContainer.HOOD;
   private final Logger logger = LoggerFactory.getLogger(this.getClass());
   private double setSpeed;

--- a/src/main/java/frc/robot/commands/magazine/LimitMagazineCommand.java
+++ b/src/main/java/frc/robot/commands/magazine/LimitMagazineCommand.java
@@ -4,7 +4,6 @@ import edu.wpi.first.wpilibj2.command.CommandBase;
 import frc.robot.RobotContainer;
 import frc.robot.subsystems.HoodSubsystem;
 import frc.robot.subsystems.MagazineSubsystem;
-import frc.robot.subsystems.ShooterSubsystem;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/frc/robot/commands/vision/WaitForTargetCommand.java
+++ b/src/main/java/frc/robot/commands/vision/WaitForTargetCommand.java
@@ -28,7 +28,8 @@ public class WaitForTargetCommand extends CommandBase {
   @Override
   public boolean isFinished() {
     return (VISION.isTargetValid()
-        && Math.abs(VISION.getOffsetAngle()) < Constants.VisionConstants.kCenteredRange);
+        && Math.abs(VISION.getOffsetAngle() - Constants.VisionConstants.kHorizAngleCorrection)
+            < Constants.VisionConstants.kCenteredRange);
   }
 
   @Override

--- a/src/main/java/frc/robot/subsystems/ClimberSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/ClimberSubsystem.java
@@ -12,22 +12,22 @@ import frc.robot.Constants;
 import frc.robot.RobotContainer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.strykeforce.thirdcoast.telemetry.TelemetryService;
-import org.strykeforce.thirdcoast.telemetry.item.TalonSRXItem;
+import org.strykeforce.telemetry.TelemetryService;
+import org.strykeforce.telemetry.measurable.TalonSRXMeasurable;
 
 public class ClimberSubsystem extends SubsystemBase {
+
   private static int TALON_ID = 50;
   private static int RATCHET_ID = 0;
 
   private static TalonSRX climb;
   private static Servo ratchet;
   private final Logger logger = LoggerFactory.getLogger(this.getClass());
-  private SupplyCurrentLimitConfiguration runningCurrent =
-      new SupplyCurrentLimitConfiguration(true, 60, 80, 1);
-
   public double ratchetReleasedTime;
   public double releaseStartTime;
   public double servoMoveTime;
+  private SupplyCurrentLimitConfiguration runningCurrent =
+      new SupplyCurrentLimitConfiguration(true, 60, 80, 1);
 
   public ClimberSubsystem() {
     climb = new TalonSRX(TALON_ID);
@@ -44,7 +44,7 @@ public class ClimberSubsystem extends SubsystemBase {
     if (!RobotContainer.isEvent) {
       TelemetryService telemetryService = RobotContainer.TELEMETRY;
       telemetryService.stop();
-      telemetryService.register(new TalonSRXItem(climb, "Climb"));
+      telemetryService.register(new TalonSRXMeasurable(climb, "Climb"));
       telemetryService.start();
     }
   }

--- a/src/main/java/frc/robot/subsystems/DeadeyeA0.java
+++ b/src/main/java/frc/robot/subsystems/DeadeyeA0.java
@@ -1,15 +1,18 @@
 package frc.robot.subsystems;
 
 import java.util.Set;
-import java.util.function.DoubleSupplier;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.strykeforce.deadeye.*;
-import org.strykeforce.thirdcoast.telemetry.item.Measurable;
-import org.strykeforce.thirdcoast.telemetry.item.Measure;
+import org.strykeforce.deadeye.Deadeye;
+import org.strykeforce.deadeye.MinAreaRectTargetData;
+import org.strykeforce.deadeye.Point2D;
+import org.strykeforce.deadeye.TargetDataListener;
+import org.strykeforce.telemetry.measurable.Measurable;
+import org.strykeforce.telemetry.measurable.Measure;
 
 public class DeadeyeA0 implements TargetDataListener<MinAreaRectTargetData>, Measurable {
+
   private static final String X = "X";
   private static final String Y = "Y";
 
@@ -99,7 +102,8 @@ public class DeadeyeA0 implements TargetDataListener<MinAreaRectTargetData>, Mea
   @NotNull
   @Override
   public Set<Measure> getMeasures() {
-    return Set.of(new Measure(X, "Target X"), new Measure(Y, "Target Y"));
+    return Set.of(
+        new Measure(X, "Target X", this::getCenterX), new Measure(Y, "Target Y", this::getCenterY));
   }
 
   @NotNull
@@ -109,25 +113,7 @@ public class DeadeyeA0 implements TargetDataListener<MinAreaRectTargetData>, Mea
   }
 
   @Override
-  public int compareTo(@NotNull Measurable measurable) {
-    return Integer.compare(getDeviceId(), measurable.getDeviceId());
-  }
-
-  @Override
   public int getDeviceId() {
     return 0;
-  }
-
-  @NotNull
-  @Override
-  public DoubleSupplier measurementFor(@NotNull Measure measure) {
-    switch (measure.getName()) {
-      case X:
-        return this::getCenterX;
-      case Y:
-        return this::getCenterY;
-      default:
-        throw new IllegalStateException("Unexpected value: " + measure.getName());
-    }
   }
 }

--- a/src/main/java/frc/robot/subsystems/DeadeyeA1.java
+++ b/src/main/java/frc/robot/subsystems/DeadeyeA1.java
@@ -3,22 +3,21 @@ package frc.robot.subsystems;
 import frc.robot.Constants;
 import java.util.List;
 import java.util.Set;
-import java.util.function.DoubleSupplier;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.strykeforce.deadeye.*;
-import org.strykeforce.thirdcoast.telemetry.item.Measurable;
-import org.strykeforce.thirdcoast.telemetry.item.Measure;
+import org.strykeforce.deadeye.Deadeye;
+import org.strykeforce.deadeye.TargetDataListener;
+import org.strykeforce.deadeye.TargetListTargetData;
+import org.strykeforce.telemetry.measurable.Measurable;
+import org.strykeforce.telemetry.measurable.Measure;
 
 public class DeadeyeA1 implements TargetDataListener<TargetListTargetData>, Measurable {
+
   private static final String NUM_TARGETS = "NUM_TARGETS";
-
-  private final Logger logger = LoggerFactory.getLogger(this.getClass());
-
   private static final double SIZE_THRESHOLD = Constants.VisionConstants.SIZE_THRESHOLD;
   private static final double DISTANCE_THRESHOLD = Constants.VisionConstants.DISTANCE_THRESHOLD;
-
+  private final Logger logger = LoggerFactory.getLogger(this.getClass());
   private final Deadeye<TargetListTargetData> deadeye =
       new Deadeye<>("A1", TargetListTargetData.class);
 
@@ -48,7 +47,9 @@ public class DeadeyeA1 implements TargetDataListener<TargetListTargetData>, Meas
   public double getLargestSize() {
     double largest = 0;
     for (TargetListTargetData.Target target : targets) {
-      if (target.contourArea > largest) largest = target.contourArea;
+      if (target.contourArea > largest) {
+        largest = target.contourArea;
+      }
     }
 
     return largest;
@@ -75,12 +76,16 @@ public class DeadeyeA1 implements TargetDataListener<TargetListTargetData>, Meas
   private boolean isBlue1() {
     int rightmost = 0;
     for (TargetListTargetData.Target target : targets) {
-      if (target.topLeft.x > rightmost) rightmost = target.topLeft.x;
+      if (target.topLeft.x > rightmost) {
+        rightmost = target.topLeft.x;
+      }
     }
 
     int leftmost = 640;
     for (TargetListTargetData.Target target : targets) {
-      if (target.topLeft.x < leftmost) leftmost = target.topLeft.x;
+      if (target.topLeft.x < leftmost) {
+        leftmost = target.topLeft.x;
+      }
     }
 
     return rightmost - leftmost > DISTANCE_THRESHOLD;
@@ -88,14 +93,6 @@ public class DeadeyeA1 implements TargetDataListener<TargetListTargetData>, Meas
 
   public void setEnabled(boolean enabled) {
     deadeye.setEnabled(enabled);
-  }
-
-  public enum Layout {
-    RED1,
-    RED2,
-    BLUE1,
-    BLUE2,
-    INVALID
   }
 
   ///////////////////////////////////////////////////////////////////////////
@@ -120,7 +117,7 @@ public class DeadeyeA1 implements TargetDataListener<TargetListTargetData>, Meas
   @NotNull
   @Override
   public Set<Measure> getMeasures() {
-    return Set.of(new Measure(NUM_TARGETS, "Number of Targets"));
+    return Set.of(new Measure(NUM_TARGETS, "Number of Targets", this::getNumTargets));
   }
 
   @NotNull
@@ -130,23 +127,15 @@ public class DeadeyeA1 implements TargetDataListener<TargetListTargetData>, Meas
   }
 
   @Override
-  public int compareTo(@NotNull Measurable measurable) {
-    return Integer.compare(getDeviceId(), measurable.getDeviceId());
-  }
-
-  @Override
   public int getDeviceId() {
     return 0;
   }
 
-  @NotNull
-  @Override
-  public DoubleSupplier measurementFor(@NotNull Measure measure) {
-    switch (measure.getName()) {
-      case NUM_TARGETS:
-        return this::getNumTargets;
-      default:
-        throw new IllegalStateException("Unexpected value: " + measure.getName());
-    }
+  public enum Layout {
+    RED1,
+    RED2,
+    BLUE1,
+    BLUE2,
+    INVALID
   }
 }

--- a/src/main/java/frc/robot/subsystems/DriveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/DriveSubsystem.java
@@ -68,6 +68,7 @@ public class DriveSubsystem extends MeasurableSubsystem {
       if (telemetryService != null) {
         telemetryService.register(azimuthTalon);
         telemetryService.register(driveTalon);
+        telemetryService.register(this);
       }
     }
 

--- a/src/main/java/frc/robot/subsystems/DriveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/DriveSubsystem.java
@@ -1,164 +1,157 @@
 package frc.robot.subsystems;
 
-import com.ctre.phoenix.motorcontrol.FeedbackDevice;
+import static frc.robot.Constants.kTalonConfigTimeout;
+
 import com.ctre.phoenix.motorcontrol.NeutralMode;
-import com.ctre.phoenix.motorcontrol.VelocityMeasPeriod;
 import com.ctre.phoenix.motorcontrol.can.TalonFX;
-import com.ctre.phoenix.motorcontrol.can.TalonFXConfiguration;
 import com.ctre.phoenix.motorcontrol.can.TalonSRX;
-import com.ctre.phoenix.motorcontrol.can.TalonSRXConfiguration;
-import com.kauailabs.navx.frc.AHRS;
+import edu.wpi.first.wpilibj.geometry.Pose2d;
+import edu.wpi.first.wpilibj.geometry.Rotation2d;
 import edu.wpi.first.wpilibj.geometry.Translation2d;
-import edu.wpi.first.wpilibj.trajectory.Trajectory;
+import edu.wpi.first.wpilibj.kinematics.SwerveDriveKinematics;
+import frc.robot.Constants.DriveConstants;
 import frc.robot.RobotContainer;
 import java.util.Set;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.strykeforce.swerve.SwerveDrive;
+import org.strykeforce.swerve.SwerveModule;
+import org.strykeforce.swerve.TalonSwerveModule;
 import org.strykeforce.telemetry.TelemetryService;
 import org.strykeforce.telemetry.measurable.MeasurableSubsystem;
 import org.strykeforce.telemetry.measurable.Measure;
 
 public class DriveSubsystem extends MeasurableSubsystem {
 
-  private static final double ROBOT_LENGTH = 25.5;
-  private static final double ROBOT_WIDTH = 21.5;
-  private static final double DRIVE_SETPOINT_MAX = 18000.0;
-  private static final int XLOCK_FL_TICKS_TARGET = 567;
-  private static final int XLOCK_FR_TICKS_TARGET = 1481;
-  private static final int AZIMUTH_TICKS = 4096;
-
-  private static final double MAX_VELOCITY = 40000; // FIXME
-  private static final double MAX_ACCELERATION = 2.0; // FIXME
-  private static final int TICKS_PER_REV = 9011; // FIXME
-  private static final double WHEEL_DIAMETER = 0.0635; // In meters
-  private static final double TICKS_PER_METER = 55451; // TICKS_PER_REV / (WHEEL_DIAMETER * Math.PI)
-  private static final double kP_PATH = 10; // FIXME?
-  private static final double MAX_VELOCITY_MPS = (MAX_VELOCITY * 10) / TICKS_PER_METER;
-  private static final double kV_PATH = 1 / MAX_VELOCITY_MPS;
-  private static final double kP_YAW = 0.01;
-  // -----------------------------------GRAPHER
-  // METHODS---------------------------------------------------
-  private static final String DESIRED_DISTANCE = "desired distance";
-  private static final String ACTUAL_DISTANCE = "actual distance";
-  private static final String DISTANCE_ERROR = "distance error";
-  private static final String PATH_VELOCITY = "path velocity";
-  private static final String DESIRED_VELOCITY = "desired path velocity";
-  private static final String FWD_PATH = "forward path";
-  private static final String STR_PATH = "strafe path";
-  private static final String YAW_PATH = "yaw path";
-  private static final String YAW_ERROR = "yaw error";
-  private static final String YAW = "yaw";
   private final Logger logger = LoggerFactory.getLogger(this.getClass());
-  private final SwerveDrive swerve = configSwerve();
+  private final SwerveDrive swerveDrive;
   TelemetryService telemetryService;
-  private Trajectory trajectoryGenerated;
-  private int[] startEncoderPosition = new int[4];
-  private double estimatedDistanceTraveled;
-  private Translation2d lastPosition;
-  private double targetYaw;
-  private double currentDistance = 0;
-  private double desiredDistance = 0;
-  private double distError = 0;
-  private double yawError = 0;
-  private double pathVelocity = 0;
-  private double desiredPathVelocity = 0;
-  private double fwdPath = 0;
-  private double strPath = 0;
-  private double yawPath = 0;
 
   public DriveSubsystem() {
-    //    swerve.setFieldOriented(true);
-    zeroAzimuths();
-  }
+    var moduleBuilder =
+        new TalonSwerveModule.Builder()
+            .driveGearRatio(DriveConstants.kDriveGearRatio)
+            .wheelDiameterInches(DriveConstants.kWheelDiameterInches)
+            .driveMaximumMetersPerSecond(DriveConstants.kMaxSpeedMetersPerSecond);
 
-  public void drive(double forward, double strafe, double yaw) {
-    //    swerve.drive(forward, strafe, yaw);
-  }
+    TalonSwerveModule[] swerveModules = new TalonSwerveModule[4];
+    Translation2d[] wheelLocations = DriveConstants.getWheelLocationMeters();
 
-  public void zeroGyro() {
-    //    AHRS gyro = swerve.getGyro();
-    //    gyro.setAngleAdjustment(0);
-    //    double adj = gyro.getAngle() % 360;
-    //    gyro.setAngleAdjustment(-adj);
-    //    logger.info("resetting gyro: ({})", adj);
-  }
-
-  public void offsetGyro(double offset) {
-    //    AHRS gyro = swerve.getGyro();
-    //    gyro.setAngleAdjustment(0);
-    //    double adj = gyro.getAngle() % 360;
-    //    gyro.setAngleAdjustment(-adj - offset);
-    //    logger.info("offsetting gyro: ({})", offset);
-  }
-
-  public void zeroAzimuths() {
-    //    swerve.zeroAzimuthEncoders();
-  }
-
-  private void getWheels() {
-    TalonSRXConfiguration azimuthConfig = new TalonSRXConfiguration();
-    azimuthConfig.primaryPID.selectedFeedbackSensor = FeedbackDevice.CTRE_MagEncoder_Relative;
-    azimuthConfig.continuousCurrentLimit = 10;
-    azimuthConfig.peakCurrentDuration = 0;
-    azimuthConfig.peakCurrentLimit = 0;
-    azimuthConfig.slot0.kP = 10.0;
-    azimuthConfig.slot0.kI = 0.0;
-    azimuthConfig.slot0.kD = 100.0;
-    azimuthConfig.slot0.kF = 0.0;
-    azimuthConfig.slot0.integralZone = 0;
-    azimuthConfig.slot0.allowableClosedloopError = 0;
-    azimuthConfig.motionAcceleration = 10_000;
-    azimuthConfig.motionCruiseVelocity = 800;
-    azimuthConfig.velocityMeasurementWindow = 64;
-    azimuthConfig.voltageCompSaturation = 12;
-
-    TalonFXConfiguration driveConfig = new TalonFXConfiguration();
-    driveConfig.supplyCurrLimit.currentLimit = 0.04;
-    driveConfig.supplyCurrLimit.triggerThresholdCurrent = 45;
-    driveConfig.supplyCurrLimit.triggerThresholdTime = 40;
-    driveConfig.supplyCurrLimit.enable = true;
-    driveConfig.slot0.kP = 0.045;
-    driveConfig.slot0.kI = 0.0005;
-    driveConfig.slot0.kD = 0.000;
-    driveConfig.slot0.kF = 0.047;
-    driveConfig.slot0.integralZone = 500;
-    driveConfig.slot0.maxIntegralAccumulator = 75_000;
-    driveConfig.slot0.allowableClosedloopError = 0;
-    driveConfig.velocityMeasurementPeriod = VelocityMeasPeriod.Period_100Ms;
-    driveConfig.velocityMeasurementWindow = 64;
-    driveConfig.voltageCompSaturation = 12;
     if (!RobotContainer.isEvent) {
       telemetryService = RobotContainer.TELEMETRY;
       telemetryService.stop();
     }
 
     for (int i = 0; i < 4; i++) {
-      TalonSRX azimuthTalon = new TalonSRX(i);
-      azimuthTalon.configAllSettings(azimuthConfig);
+      var azimuthTalon = new TalonSRX(i);
+      azimuthTalon.configFactoryDefault(kTalonConfigTimeout);
+      azimuthTalon.configAllSettings(DriveConstants.getAzimuthTalonConfig(), kTalonConfigTimeout);
       azimuthTalon.enableCurrentLimit(true);
       azimuthTalon.enableVoltageCompensation(true);
       azimuthTalon.setNeutralMode(NeutralMode.Coast);
 
-      TalonFX driveTalon = new TalonFX(i + 10);
-      driveTalon.configAllSettings(driveConfig);
-      driveTalon.setNeutralMode(NeutralMode.Brake);
+      var driveTalon = new TalonFX(i + 10);
+      driveTalon.configFactoryDefault(kTalonConfigTimeout);
+      driveTalon.configAllSettings(DriveConstants.getDriveTalonConfig(), kTalonConfigTimeout);
       driveTalon.enableVoltageCompensation(true);
-      if (!RobotContainer.isEvent) {
-        //        telemetryService.register(new TalonSRXItem(azimuthTalon, "Azimuth " + i));
-        //        telemetryService.register(new TalonFXItem(driveTalon, "Drive " + (i + 10)));
+      driveTalon.setNeutralMode(NeutralMode.Brake);
+
+      swerveModules[i] =
+          moduleBuilder
+              .azimuthTalon(azimuthTalon)
+              .driveTalon(driveTalon)
+              .wheelLocationMeters(wheelLocations[i])
+              .build();
+
+      swerveModules[i].loadAndSetAzimuthZeroReference();
+      if (telemetryService != null) {
+        telemetryService.register(azimuthTalon);
+        telemetryService.register(driveTalon);
       }
-      //      wheels[i] = new Wheel(azimuthTalon, driveTalon, DRIVE_SETPOINT_MAX);
     }
-    if (!RobotContainer.isEvent) {
-      telemetryService.register(this);
-      telemetryService.start();
-    }
+
+    swerveDrive = new SwerveDrive(swerveModules);
+    swerveDrive.resetGyro();
   }
 
-  private SwerveDrive configSwerve() {
-    return null;
+  /**
+   * Returns the swerve drive kinematics object for use during trajectory configuration.
+   *
+   * @return the configured kinemetics object
+   */
+  public SwerveDriveKinematics getSwerveDriveKinematics() {
+    return swerveDrive.getKinematics();
+  }
+
+  /** Returns the configured swerve drive modules. */
+  public SwerveModule[] getSwerveModules() {
+    return swerveDrive.getSwerveModules();
+  }
+
+  /**
+   * Resets the robot's position on the field.
+   *
+   * @param pose the current pose
+   */
+  public void resetOdometry(Pose2d pose) {
+    swerveDrive.resetOdometry(pose);
+    logger.info("reset odometry with pose = {}", pose);
+  }
+
+  /**
+   * Returns the position of the robot on the field.
+   *
+   * @return the pose of the robot (x and y ane in meters)
+   */
+  public Pose2d getPoseMeters() {
+    return swerveDrive.getPoseMeters();
+  }
+
+  /** Perform periodic swerve drive odometry update. */
+  @Override
+  public void periodic() {
+    swerveDrive.periodic();
+  }
+
+  /** Drive the robot with given x, y, and rotational velocities with open-loop velocity control. */
+  public void drive(
+      double vxMetersPerSecond, double vyMetersPerSecond, double omegaRadiansPerSecond) {
+    swerveDrive.drive(vxMetersPerSecond, vyMetersPerSecond, omegaRadiansPerSecond, true);
+  }
+
+  /**
+   * Move the robot with given x, y, and rotational velocities with closed-loop velocity control.
+   */
+  public void move(
+      double vxMetersPerSecond,
+      double vyMetersPerSecond,
+      double omegaRadiansPerSecond,
+      boolean isFieldOriented) {
+    swerveDrive.move(vxMetersPerSecond, vyMetersPerSecond, omegaRadiansPerSecond, isFieldOriented);
+  }
+
+  public void resetGyro() {
+    swerveDrive.resetGyro();
+  }
+
+  public Rotation2d getHeading() {
+    return swerveDrive.getHeading();
+  }
+
+  // Measurable Support
+
+  @NotNull
+  @Override
+  public Set<Measure> getMeasures() {
+    return Set.of(
+        new Measure("Gyro Rotation2d (deg)", () -> swerveDrive.getHeading().getDegrees()),
+        new Measure("Gyro Angle (deg)", swerveDrive::getGyroAngle),
+        new Measure("Odometry X", () -> swerveDrive.getPoseMeters().getX()),
+        new Measure("Odometry Y", () -> swerveDrive.getPoseMeters().getY()),
+        new Measure(
+            "Odometry Rotation2d (deg)",
+            () -> swerveDrive.getPoseMeters().getRotation().getDegrees()));
   }
 
   public void xLockSwerveDrive() {
@@ -189,56 +182,5 @@ public class DriveSubsystem extends MeasurableSubsystem {
     //        swerveWheels[i].setAzimuthPosition(position + delta);
     //      }
     //    }
-  }
-
-  public void zeroSwerve() {
-    //    Wheel[] swerveWheels = swerve.getWheels();
-    //    for (int i = 0; i < 4; i++) {
-    //      swerveWheels[i].setAzimuthPosition(0);
-    //    }
-  }
-
-  public AHRS getGyro() {
-    throw new UnsupportedOperationException("gyro not implemented");
-  }
-
-  // ----------------------------------Path
-  // Methods--------------------------------------------------
-  public Trajectory calculateTrajectory(String name) {
-    throw new UnsupportedOperationException("old path code");
-  }
-
-  public void startPath(Trajectory trajectoryGenerated, double targetYaw) {
-    throw new UnsupportedOperationException("old path code");
-  }
-
-  public void updatePathOutput(double timeSeconds) {
-    throw new UnsupportedOperationException("old path code");
-  }
-
-  public boolean isPathDone(double timePassedSeconds) {
-    throw new UnsupportedOperationException("old path code");
-  }
-
-  @NotNull
-  @Override
-  public Set<Measure> getMeasures() {
-    return Set.of(
-        new Measure(DESIRED_DISTANCE, "desired distance", () -> desiredDistance),
-        new Measure(ACTUAL_DISTANCE, "actual distance", () -> currentDistance),
-        new Measure(DISTANCE_ERROR, "distance error", () -> distError),
-        new Measure(PATH_VELOCITY, "path velocity", () -> pathVelocity),
-        new Measure(DESIRED_VELOCITY, "desired path velocity", () -> desiredPathVelocity),
-        new Measure(FWD_PATH, "forward path", () -> fwdPath),
-        new Measure(STR_PATH, "strafe path", () -> strPath),
-        new Measure(YAW_PATH, "yaw path", () -> yawPath),
-        new Measure(YAW_ERROR, "yaw_error", () -> yawError),
-        new Measure(
-            YAW,
-            "yaw",
-            () -> {
-              throw new UnsupportedOperationException();
-            }));
-    //        new Measure(YAW, "yaw", () -> Math.IEEEremainder(swerve.getGyro().getAngle(), 360)));
   }
 }

--- a/src/main/java/frc/robot/subsystems/HoodSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/HoodSubsystem.java
@@ -1,6 +1,11 @@
 package frc.robot.subsystems;
 
-import com.ctre.phoenix.motorcontrol.*;
+import com.ctre.phoenix.motorcontrol.ControlMode;
+import com.ctre.phoenix.motorcontrol.LimitSwitchNormal;
+import com.ctre.phoenix.motorcontrol.LimitSwitchSource;
+import com.ctre.phoenix.motorcontrol.NeutralMode;
+import com.ctre.phoenix.motorcontrol.SupplyCurrentLimitConfiguration;
+import com.ctre.phoenix.motorcontrol.VelocityMeasPeriod;
 import com.ctre.phoenix.motorcontrol.can.BaseTalon;
 import com.ctre.phoenix.motorcontrol.can.TalonSRX;
 import com.ctre.phoenix.motorcontrol.can.TalonSRXConfiguration;
@@ -11,24 +16,19 @@ import frc.robot.RobotContainer;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.strykeforce.thirdcoast.telemetry.TelemetryService;
-import org.strykeforce.thirdcoast.telemetry.item.TalonSRXItem;
+import org.strykeforce.telemetry.TelemetryService;
+import org.strykeforce.telemetry.measurable.TalonSRXMeasurable;
 
 public class HoodSubsystem extends SubsystemBase {
+
   private static final DriveSubsystem DRIVE = RobotContainer.DRIVE;
-  private final Logger logger = LoggerFactory.getLogger(this.getClass());
-
+  private static final int HOOD_ID = 43;
+  private static final double HOOD_TICKS_PER_DEGREE = Constants.HoodConstants.HOOD_TICKS_PER_DEGREE;
   private static TalonSRX hood;
-
   private static double targetHoodPosition = 0;
   private static int hoodStableCounts = 0;
-
-  private static final int HOOD_ID = 43;
-
-  private static final double HOOD_TICKS_PER_DEGREE = Constants.HoodConstants.HOOD_TICKS_PER_DEGREE;
-
   private static int kHoodZeroTicks;
-
+  private final Logger logger = LoggerFactory.getLogger(this.getClass());
   TelemetryService telService;
 
   public HoodSubsystem() {
@@ -67,7 +67,7 @@ public class HoodSubsystem extends SubsystemBase {
     if (!RobotContainer.isEvent) {
       TelemetryService telService = RobotContainer.TELEMETRY;
       telService.stop();
-      telService.register(new TalonSRXItem(hood, "ShooterHood"));
+      telService.register(new TalonSRXMeasurable(hood, "ShooterHood"));
       telService.start();
     }
   }
@@ -98,14 +98,14 @@ public class HoodSubsystem extends SubsystemBase {
     return didZero;
   }
 
+  public int getHoodPosition() {
+    return (int) hood.getSelectedSensorPosition();
+  }
+
   public void setHoodPosition(int position) {
     hood.set(ControlMode.MotionMagic, position);
     targetHoodPosition = position;
     logger.info("Setting Hood to {} ticks", position);
-  }
-
-  public int getHoodPosition() {
-    return (int) hood.getSelectedSensorPosition();
   }
 
   public void hoodOpenLoop(double output) {

--- a/src/main/java/frc/robot/subsystems/IntakeSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/IntakeSubsystem.java
@@ -1,17 +1,20 @@
 package frc.robot.subsystems;
 
 import com.ctre.phoenix.motorcontrol.ControlMode;
-import com.ctre.phoenix.motorcontrol.can.*;
+import com.ctre.phoenix.motorcontrol.can.BaseTalon;
+import com.ctre.phoenix.motorcontrol.can.TalonFX;
+import com.ctre.phoenix.motorcontrol.can.TalonFXConfiguration;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.robot.Constants;
 import frc.robot.RobotContainer;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.strykeforce.thirdcoast.talon.TalonFXItem;
-import org.strykeforce.thirdcoast.telemetry.TelemetryService;
+import org.strykeforce.telemetry.TelemetryService;
+import org.strykeforce.thirdcoast.talon.TalonFXMeasurable;
 
 public class IntakeSubsystem extends SubsystemBase {
+
   public static double lastIntakePressedTime = 0;
 
   public static int SQUIDS_ID = 20;
@@ -43,8 +46,8 @@ public class IntakeSubsystem extends SubsystemBase {
     if (!RobotContainer.isEvent) {
       TelemetryService telemetryService = RobotContainer.TELEMETRY;
       telemetryService.stop();
-      telemetryService.register(new TalonFXItem(squidsDrive, "Squids"));
-      telemetryService.register(new TalonFXItem(intakeDrive, "Intake"));
+      telemetryService.register(new TalonFXMeasurable(squidsDrive, "Squids"));
+      telemetryService.register(new TalonFXMeasurable(intakeDrive, "Intake"));
       telemetryService.start();
     }
   }
@@ -85,7 +88,11 @@ public class IntakeSubsystem extends SubsystemBase {
           < Constants.IntakeConstants.kStallVelocity) {
         logger.info("Squids Stalled");
         return true;
-      } else return false;
-    } else return false;
+      } else {
+        return false;
+      }
+    } else {
+      return false;
+    }
   }
 }

--- a/src/main/java/frc/robot/subsystems/MagazineSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/MagazineSubsystem.java
@@ -9,8 +9,8 @@ import frc.robot.RobotContainer;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.strykeforce.thirdcoast.telemetry.TelemetryService;
-import org.strykeforce.thirdcoast.telemetry.item.TalonSRXItem;
+import org.strykeforce.telemetry.TelemetryService;
+import org.strykeforce.telemetry.measurable.TalonSRXMeasurable;
 
 public class MagazineSubsystem extends SubsystemBase {
   private static final int MAGAZINE_ID = 30;
@@ -49,7 +49,7 @@ public class MagazineSubsystem extends SubsystemBase {
     if (!RobotContainer.isEvent) {
       TelemetryService telemetry = RobotContainer.TELEMETRY;
       telemetry.stop();
-      telemetry.register(new TalonSRXItem(magazineTalon, "Magazine"));
+      telemetry.register(new TalonSRXMeasurable(magazineTalon, "Magazine"));
       telemetry.start();
     }
   }

--- a/src/main/java/frc/robot/subsystems/ShooterSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/ShooterSubsystem.java
@@ -1,30 +1,31 @@
 package frc.robot.subsystems;
 
-import com.ctre.phoenix.motorcontrol.*;
-import com.ctre.phoenix.motorcontrol.can.*;
+import com.ctre.phoenix.motorcontrol.ControlMode;
+import com.ctre.phoenix.motorcontrol.NeutralMode;
+import com.ctre.phoenix.motorcontrol.VelocityMeasPeriod;
+import com.ctre.phoenix.motorcontrol.can.BaseTalon;
+import com.ctre.phoenix.motorcontrol.can.TalonFX;
+import com.ctre.phoenix.motorcontrol.can.TalonFXConfiguration;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.robot.Constants;
 import frc.robot.RobotContainer;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.strykeforce.thirdcoast.talon.TalonFXItem;
-import org.strykeforce.thirdcoast.telemetry.TelemetryService;
+import org.strykeforce.telemetry.TelemetryService;
+import org.strykeforce.thirdcoast.talon.TalonFXMeasurable;
 
 public class ShooterSubsystem extends SubsystemBase {
-  private static final DriveSubsystem DRIVE = RobotContainer.DRIVE;
-  private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
+  private static final DriveSubsystem DRIVE = RobotContainer.DRIVE;
+  private static final int L_MASTER_ID = 40;
+  private static final int R_SLAVE_ID = 41;
   private static TalonFX leftMaster;
   private static TalonFX rightSlave;
-
   private static boolean isArmed = false;
   private static int targetShooterSpeed = 0;
   private static int shooterStableCounts = 0;
-
-  private static final int L_MASTER_ID = 40;
-  private static final int R_SLAVE_ID = 41;
-
+  private final Logger logger = LoggerFactory.getLogger(this.getClass());
   TelemetryService telService;
 
   public ShooterSubsystem() {
@@ -60,8 +61,8 @@ public class ShooterSubsystem extends SubsystemBase {
     if (!RobotContainer.isEvent) {
       TelemetryService telService = RobotContainer.TELEMETRY;
       telService.stop();
-      telService.register(new TalonFXItem(leftMaster, "ShooterLeftMaster"));
-      telService.register(new TalonFXItem(rightSlave, "ShooterRightSlave"));
+      telService.register(new TalonFXMeasurable(leftMaster, "ShooterLeftMaster"));
+      telService.register(new TalonFXMeasurable(rightSlave, "ShooterRightSlave"));
       telService.start();
     }
   }

--- a/src/main/java/frc/robot/subsystems/TurretSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/TurretSubsystem.java
@@ -113,7 +113,8 @@ public class TurretSubsystem extends SubsystemBase {
   }
 
   public void seekTarget(double angleOffset) {
-    double bearing = (DRIVE.getGyro().getAngle() + 270 + angleOffset) % 360;
+    // TODO: convert to DRIVE.getHeading()
+    double bearing = 0; // (DRIVE.getGyro().getAngle() + 270 + angleOffset) % 360;
     if (bearing < 0) {
       bearing += 360;
     }

--- a/src/main/java/frc/robot/subsystems/TurretSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/TurretSubsystem.java
@@ -113,8 +113,7 @@ public class TurretSubsystem extends SubsystemBase {
   }
 
   public void seekTarget(double angleOffset) {
-    // TODO: convert to DRIVE.getHeading()
-    double bearing = 0; // (DRIVE.getGyro().getAngle() + 270 + angleOffset) % 360;
+    double bearing = (DRIVE.getHeading().getDegrees() + 270 + angleOffset) % 360;
     if (bearing < 0) {
       bearing += 360;
     }

--- a/src/main/java/frc/robot/subsystems/TurretSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/TurretSubsystem.java
@@ -1,6 +1,9 @@
 package frc.robot.subsystems;
 
-import com.ctre.phoenix.motorcontrol.*;
+import com.ctre.phoenix.motorcontrol.ControlMode;
+import com.ctre.phoenix.motorcontrol.LimitSwitchNormal;
+import com.ctre.phoenix.motorcontrol.NeutralMode;
+import com.ctre.phoenix.motorcontrol.SupplyCurrentLimitConfiguration;
 import com.ctre.phoenix.motorcontrol.can.BaseTalon;
 import com.ctre.phoenix.motorcontrol.can.TalonSRX;
 import com.ctre.phoenix.motorcontrol.can.TalonSRXConfiguration;
@@ -10,29 +13,24 @@ import frc.robot.RobotContainer;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.strykeforce.thirdcoast.telemetry.TelemetryService;
-import org.strykeforce.thirdcoast.telemetry.item.TalonSRXItem;
+import org.strykeforce.telemetry.TelemetryService;
+import org.strykeforce.telemetry.measurable.TalonSRXMeasurable;
 
 public class TurretSubsystem extends SubsystemBase {
+
   private static final DriveSubsystem DRIVE = RobotContainer.DRIVE;
-  private final Logger logger = LoggerFactory.getLogger(this.getClass());
-
-  private static TalonSRX turret;
-
-  private static double targetTurretPosition = 0;
-
-  private static int turretStableCounts = 0;
-
   private static final int TURRET_ID = 42;
-
   private static final double TURRET_TICKS_PER_DEGREE =
       Constants.TurretConstants.TURRET_TICKS_PER_DEGREE;
-
-  private static int kTurretZeroTicks;
   private static final double kWrapRange = Constants.TurretConstants.kWrapRange;
   private static final double kTurretMidpoint = Constants.TurretConstants.kTurretMidpoint;
-  TelemetryService telService;
   public static boolean talonReset;
+  private static TalonSRX turret;
+  private static double targetTurretPosition = 0;
+  private static int turretStableCounts = 0;
+  private static int kTurretZeroTicks;
+  private final Logger logger = LoggerFactory.getLogger(this.getClass());
+  TelemetryService telService;
 
   public TurretSubsystem() {
     kTurretZeroTicks = Constants.TurretConstants.kTurretZeroTicks;
@@ -68,7 +66,7 @@ public class TurretSubsystem extends SubsystemBase {
     if (!RobotContainer.isEvent) {
       TelemetryService telService = RobotContainer.TELEMETRY;
       telService.stop();
-      telService.register(new TalonSRXItem(turret, "ShooterTurret"));
+      telService.register(new TalonSRXMeasurable(turret, "ShooterTurret"));
       telService.start();
     }
   }
@@ -114,27 +112,20 @@ public class TurretSubsystem extends SubsystemBase {
     setTurret(setPoint);
   }
 
-  public void setTurretAngle(double targetAngle) {
-    if (targetAngle <= kWrapRange && turret.getSelectedSensorPosition() > kTurretMidpoint
-        || targetAngle < 0) {
-      targetAngle += 360;
-    }
-    double setPoint = targetAngle * TURRET_TICKS_PER_DEGREE;
-    logger.info("Rotating Turret to {} degrees", targetAngle);
-    setTurret(setPoint);
-  }
-
   public void seekTarget(double angleOffset) {
     double bearing = (DRIVE.getGyro().getAngle() + 270 + angleOffset) % 360;
-    if (bearing < 0) bearing += 360;
+    if (bearing < 0) {
+      bearing += 360;
+    }
     double setPoint = bearing * TURRET_TICKS_PER_DEGREE;
     setTurret(setPoint);
     //    logger.info("Seeking Target with {} degree offset", angleOffset);
   }
 
   public void setTurret(double setPoint) {
-    if (turret.hasResetOccurred()) talonReset = true;
-    else {
+    if (turret.hasResetOccurred()) {
+      talonReset = true;
+    } else {
       targetTurretPosition = setPoint;
       turret.set(ControlMode.MotionMagic, setPoint);
       //      logger.info("Rotating Turret to {} ticks", setPoint);
@@ -165,6 +156,16 @@ public class TurretSubsystem extends SubsystemBase {
 
   public double getTurretAngle() {
     return turret.getSelectedSensorPosition() / TURRET_TICKS_PER_DEGREE;
+  }
+
+  public void setTurretAngle(double targetAngle) {
+    if (targetAngle <= kWrapRange && turret.getSelectedSensorPosition() > kTurretMidpoint
+        || targetAngle < 0) {
+      targetAngle += 360;
+    }
+    double setPoint = targetAngle * TURRET_TICKS_PER_DEGREE;
+    logger.info("Rotating Turret to {} degrees", targetAngle);
+    setTurret(setPoint);
   }
 
   public int getTurretError() {

--- a/src/main/java/frc/robot/subsystems/VisionSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/VisionSubsystem.java
@@ -171,11 +171,10 @@ public class VisionSubsystem extends MeasurableSubsystem {
   }
 
   public double getCorrectedWidth() {
-    // TODO: convert to drive.getHeading()
-    double fieldOrientedOffset = 0;
-    //        (Math.IEEEremainder(drive.getGyro().getAngle(), 360)
-    //            + (270 - turret.getTurretAngle())
-    //            + getOffsetAngle());
+    double fieldOrientedOffset =
+        (Math.IEEEremainder(-drive.getHeading().getDegrees(), 360)
+            + (270 - turret.getTurretAngle())
+            + getOffsetAngle());
     if (shooterCamera.getValid()) {
       return getRawWidth() / Math.cos(Math.toRadians(fieldOrientedOffset));
     } else {

--- a/src/main/java/frc/robot/subsystems/VisionSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/VisionSubsystem.java
@@ -17,14 +17,6 @@ import org.strykeforce.telemetry.measurable.MeasurableSubsystem;
 import org.strykeforce.telemetry.measurable.Measure;
 
 public class VisionSubsystem extends MeasurableSubsystem {
-
-  private static final String RANGE = "RANGE";
-  private static final String GROUND_RANGE = "GROUND_RANGE";
-  private static final String BEARING = "BEARING";
-  private static final String X_OFFSET = "X_OFFSET";
-  private static final String RAW_WIDTH = "RAW_WIDTH";
-  private static final String CORRECTED_WIDTH = "CORRECTED_WIDTH";
-
   public static double VERTICAL_FOV;
   public static double HORIZ_FOV;
   public static double HORIZ_RES;
@@ -179,10 +171,11 @@ public class VisionSubsystem extends MeasurableSubsystem {
   }
 
   public double getCorrectedWidth() {
-    double fieldOrientedOffset =
-        (Math.IEEEremainder(drive.getGyro().getAngle(), 360)
-            + (270 - turret.getTurretAngle())
-            + getOffsetAngle());
+    // TODO: convert to drive.getHeading()
+    double fieldOrientedOffset = 0;
+    //        (Math.IEEEremainder(drive.getGyro().getAngle(), 360)
+    //            + (270 - turret.getTurretAngle())
+    //            + getOffsetAngle());
     if (shooterCamera.getValid()) {
       return getRawWidth() / Math.cos(Math.toRadians(fieldOrientedOffset));
     } else {
@@ -296,11 +289,11 @@ public class VisionSubsystem extends MeasurableSubsystem {
   @Override
   public Set<Measure> getMeasures() {
     return Set.of(
-        new Measure(RANGE, "Raw Range", this::getDistance),
-        new Measure(GROUND_RANGE, "Ground Range", this::getGroundDistance),
-        new Measure(BEARING, "Bearing", this::getOffsetAngle),
-        new Measure(X_OFFSET, "Pixel offset", this::getPixOffset),
-        new Measure(RAW_WIDTH, "Raw Pixel Width", this::getRawWidth),
-        new Measure(CORRECTED_WIDTH, "Corrected Pixel Width", this::getCorrectedWidth));
+        new Measure("Raw Range", this::getDistance),
+        new Measure("Ground Range", this::getGroundDistance),
+        new Measure("Bearing", this::getOffsetAngle),
+        new Measure("Pixel offset", this::getPixOffset),
+        new Measure("Raw Pixel Width", this::getRawWidth),
+        new Measure("Corrected Pixel Width", this::getCorrectedWidth));
   }
 }

--- a/src/main/kotlin/frc/robot/commands/HealthCheckCommand.kt
+++ b/src/main/kotlin/frc/robot/commands/HealthCheckCommand.kt
@@ -318,7 +318,5 @@ class HealthCheckCommand : CommandBase() {
 
     override fun end(interrupted: Boolean) {
         healthCheck.report()
-        // TODO: convert to new swerve
-//        RobotContainer.DRIVE.zeroSwerve()
     }
 }

--- a/src/main/kotlin/frc/robot/commands/HealthCheckCommand.kt
+++ b/src/main/kotlin/frc/robot/commands/HealthCheckCommand.kt
@@ -3,8 +3,8 @@ package frc.robot.commands
 import edu.wpi.first.wpilibj2.command.CommandBase
 import frc.robot.RobotContainer
 import mu.KotlinLogging
-import org.strykeforce.thirdcoast.healthcheck.HealthCheck
-import org.strykeforce.thirdcoast.healthcheck.healthCheck
+import org.strykeforce.healthcheck.HealthCheck
+import org.strykeforce.healthcheck.healthCheck
 
 private val logger = KotlinLogging.logger { }
 
@@ -24,293 +24,293 @@ class HealthCheckCommand : CommandBase() {
     private lateinit var healthCheck: HealthCheck
 
     override fun initialize() {
-        healthCheck = healthCheck {
-            //Azimuth Motors
-            talonCheck {
-                name = "swerve azimuth tests"
-                talons = RobotContainer.DRIVE.allWheels.map { it.azimuthTalon }
-
-                val volt3supplyCurrentRange = 0.25..0.75
-                val volt6supplyCurrentRange = 0.5..1.25
-                val volt9supplyCurrentRange = 1.0..1.5
-
-                val volt3statorCurrentRange = 0.25..0.75
-                val volt6statorCurrentRange = 0.5..1.25
-                val volt9statorCurrentRange = 1.0..1.5
-
-                timedTest {
-                    percentOutput = 0.25
-                    supplyCurrentRange = volt3supplyCurrentRange
-                    statorCurrentRange = volt3statorCurrentRange
-                    speedRange = 215..250
-                }
-
-                timedTest {
-                    percentOutput = -0.25
-                    supplyCurrentRange = volt3supplyCurrentRange
-                    statorCurrentRange = volt3statorCurrentRange
-                    speedRange = -250..-215
-                }
-
-                timedTest {
-                    percentOutput = 0.5
-                    supplyCurrentRange = volt6supplyCurrentRange
-                    statorCurrentRange = volt6statorCurrentRange
-                    speedRange = 475..535
-                }
-
-                timedTest {
-                    percentOutput = -0.5
-                    supplyCurrentRange = volt6supplyCurrentRange
-                    statorCurrentRange = volt6statorCurrentRange
-                    speedRange = -535..-475
-                }
-
-                timedTest {
-                    percentOutput = 0.75
-                    supplyCurrentRange = volt9supplyCurrentRange
-                    statorCurrentRange = volt9statorCurrentRange
-                    speedRange = 750..820
-                }
-
-                timedTest {
-                    percentOutput = -0.75
-                    supplyCurrentRange = volt9supplyCurrentRange
-                    statorCurrentRange = volt9statorCurrentRange
-                    speedRange = -820..-750
-                }
-            }
-
-            //Drive Motors
-            talonCheck {
-                name = "swerve drive tests"
-                talons = RobotContainer.DRIVE.allWheels.map { it.driveTalon }
-
-                val volt3supplyCurrentRange = 0.5..1.125
-                val volt6supplyCurrentRange = 1.0..2.0
-                val volt12supplyCurrentRange = 2.5..5.0
-
-                val volt3statorCurrentRange = 0.5..1.125
-                val volt6statorCurrentRange = 1.0..2.0
-                val volt12statorCurrentRange = 2.5..5.0
-
-                timedTest {
-                    percentOutput = 0.25
-                    supplyCurrentRange = volt3supplyCurrentRange
-                    statorCurrentRange = volt3statorCurrentRange
-                    speedRange = 8500..9500
-                }
-
-                timedTest {
-                    percentOutput = -0.25
-                    supplyCurrentRange = volt3supplyCurrentRange
-                    statorCurrentRange = volt3statorCurrentRange
-                    speedRange = -9500..-8500
-                }
-
-                timedTest {
-                    percentOutput = 0.5
-                    supplyCurrentRange = volt6supplyCurrentRange
-                    statorCurrentRange = volt6statorCurrentRange
-                    speedRange = 17200..19500
-                }
-
-                timedTest {
-                    percentOutput = -0.5
-                    supplyCurrentRange = volt6supplyCurrentRange
-                    statorCurrentRange = volt6statorCurrentRange
-                    speedRange = -19500..-17200
-                }
-
-                timedTest {
-                    percentOutput = 1.0
-                    supplyCurrentRange = volt12supplyCurrentRange
-                    statorCurrentRange = volt12statorCurrentRange
-                    speedRange = 34750..39500
-                }
-
-                timedTest {
-                    percentOutput = -1.0
-                    supplyCurrentRange = volt12supplyCurrentRange
-                    statorCurrentRange = volt12statorCurrentRange
-                    speedRange = -39500..-34750
-                }
-            }
-
-            //Intake Tests
-            talonCheck {
-                name = "intake tests"
-                talons = RobotContainer.INTAKE.talons
-
-                val volt6supplycurrentRange = 1.0..4.0
-
-                val volt6statorCurrentRange = 1.0..4.0
-
-                timedTest {
-                    percentOutput = 0.5
-                    supplyCurrentRange = volt6supplycurrentRange
-                    statorCurrentRange = volt6statorCurrentRange
-                    speedRange = 3500..4500
-                }
-
-                timedTest {
-                    percentOutput = -0.5
-                    supplyCurrentRange = volt6supplycurrentRange
-                    statorCurrentRange = volt6statorCurrentRange
-                    speedRange = -4500..-3500
-                }
-            }
-
-            //Magazine Tests
-            talonCheck {
-                name = "magazine tests"
-                talons = RobotContainer.MAGAZINE.talons
-
-                val volt6supplyCurrentRange = 1.0..4.0
-                val volt12supplyCurrentRange = 13.0..17.0
-
-                val volt6statorCurrentRange = 1.0..4.0
-                val volt12statorCurrentRange = 13.0..17.0
-
-                timedTest {
-                    percentOutput = 0.5
-                    supplyCurrentRange = volt6supplyCurrentRange
-                    statorCurrentRange = volt6statorCurrentRange
-                    speedRange = 2000..3000
-                }
-
-                timedTest {
-                    percentOutput = -0.5
-                    supplyCurrentRange = volt6supplyCurrentRange
-                    statorCurrentRange = volt6statorCurrentRange
-                    speedRange = -3000..-2000
-                }
-
-                timedTest {
-                    percentOutput = 1.0
-                    supplyCurrentRange = volt12supplyCurrentRange
-                    statorCurrentRange = volt12statorCurrentRange
-                    speedRange = 3500..5000
-                }
-
-                timedTest {
-                    percentOutput = -1.0
-                    supplyCurrentRange = volt12supplyCurrentRange
-                    statorCurrentRange = volt12statorCurrentRange
-                    speedRange = -5000..-3500
-                }
-            }
-
-            //Shooter Tests
-            talonCheck {
-                name = "shooter tests"
-                talons = RobotContainer.SHOOTER.talons
-
-                val volt10_000supplyCurrentRange = 1.0..4.0
-                val volt16_000supplyCurrentRange = 13.0..17.0
-
-                val volt10_000statorCurrentRange = 1.0..4.0
-                val volt16_000statorCurrentRange = 13.0..17.0
-
-                followerTimedTest {
-                    percentOutput = 0.53
-                    supplyCurrentRange = volt10_000supplyCurrentRange
-                    statorCurrentRange = volt10_000statorCurrentRange
-                    speedRange = 8_000..12_000
-                }
-
-                followerTimedTest {
-                    percentOutput = 0.84
-                    supplyCurrentRange = volt16_000supplyCurrentRange
-                    statorCurrentRange = volt16_000statorCurrentRange
-                    speedRange = 14_000..19_000
-                }
-
-            }
-
-            //Turret Tests
-            talonCheck {
-                name = "turret tests"
-                talons = RobotContainer.TURRET.talons
-
-                val supplyCurrent = 0.375..1.0
-                val statorCurrent = 0.375..1.0
-
-
-                positionTalon {
-                    encoderTarget = 0
-                    encoderGoodEnough = 100
-                }
-
-                positionTest {
-                    percentOutput = 0.2
-                    encoderChangeTarget = 25_000
-                    encoderGoodEnough = 500
-                    encoderTimeCount = 500
-
-                    supplyCurrentRange = supplyCurrent
-                    statorCurrentRange = statorCurrent
-                    speedRange = 550..750
-                }
-
-                positionTest {
-                    percentOutput = -0.2
-                    encoderChangeTarget = 25_000
-                    encoderGoodEnough = 500
-                    encoderTimeCount = 500
-
-                    supplyCurrentRange = supplyCurrent
-                    statorCurrentRange = statorCurrent
-                    speedRange = -750..-550
-                }
-
-            }
-
-            //Hood Tests
-            talonCheck {
-                name = "hood tests"
-                talons = RobotContainer.HOOD.talons
-
-                val supplyCurrent = 0.375..1.0
-                val statorCurrent = 0.375..1.0
-
-                positionTalon {
-                    encoderTarget = 0
-                    encoderGoodEnough = 100
-                }
-
-                positionTest {
-                    percentOutput = 0.2
-                    encoderChangeTarget = 7000
-                    encoderGoodEnough = 500
-                    encoderTimeCount = 500
-
-                    supplyCurrentRange = supplyCurrent
-                    statorCurrentRange = statorCurrent
-                }
-
-                positionTest {
-                    percentOutput = -0.2
-                    encoderChangeTarget = 7000
-                    encoderGoodEnough = 500
-                    encoderTimeCount = 500
-
-                    supplyCurrentRange = supplyCurrent
-                    statorCurrentRange = statorCurrent
-                }
-            }
-
-        }
+//        healthCheck = healthCheck {
+//            //Azimuth Motors
+//            talonCheck {
+//                name = "swerve azimuth tests"
+//                talons = RobotContainer.DRIVE.allWheels.map { it.azimuthTalon }
+//
+//                val volt3supplyCurrentRange = 0.25..0.75
+//                val volt6supplyCurrentRange = 0.5..1.25
+//                val volt9supplyCurrentRange = 1.0..1.5
+//
+//                val volt3statorCurrentRange = 0.25..0.75
+//                val volt6statorCurrentRange = 0.5..1.25
+//                val volt9statorCurrentRange = 1.0..1.5
+//
+//                timedTest {
+//                    percentOutput = 0.25
+//                    supplyCurrentRange = volt3supplyCurrentRange
+//                    statorCurrentRange = volt3statorCurrentRange
+//                    speedRange = 215..250
+//                }
+//
+//                timedTest {
+//                    percentOutput = -0.25
+//                    supplyCurrentRange = volt3supplyCurrentRange
+//                    statorCurrentRange = volt3statorCurrentRange
+//                    speedRange = -250..-215
+//                }
+//
+//                timedTest {
+//                    percentOutput = 0.5
+//                    supplyCurrentRange = volt6supplyCurrentRange
+//                    statorCurrentRange = volt6statorCurrentRange
+//                    speedRange = 475..535
+//                }
+//
+//                timedTest {
+//                    percentOutput = -0.5
+//                    supplyCurrentRange = volt6supplyCurrentRange
+//                    statorCurrentRange = volt6statorCurrentRange
+//                    speedRange = -535..-475
+//                }
+//
+//                timedTest {
+//                    percentOutput = 0.75
+//                    supplyCurrentRange = volt9supplyCurrentRange
+//                    statorCurrentRange = volt9statorCurrentRange
+//                    speedRange = 750..820
+//                }
+//
+//                timedTest {
+//                    percentOutput = -0.75
+//                    supplyCurrentRange = volt9supplyCurrentRange
+//                    statorCurrentRange = volt9statorCurrentRange
+//                    speedRange = -820..-750
+//                }
+//            }
+//
+//            //Drive Motors
+//            talonCheck {
+//                name = "swerve drive tests"
+//                talons = RobotContainer.DRIVE.allWheels.map { it.driveTalon }
+//
+//                val volt3supplyCurrentRange = 0.5..1.125
+//                val volt6supplyCurrentRange = 1.0..2.0
+//                val volt12supplyCurrentRange = 2.5..5.0
+//
+//                val volt3statorCurrentRange = 0.5..1.125
+//                val volt6statorCurrentRange = 1.0..2.0
+//                val volt12statorCurrentRange = 2.5..5.0
+//
+//                timedTest {
+//                    percentOutput = 0.25
+//                    supplyCurrentRange = volt3supplyCurrentRange
+//                    statorCurrentRange = volt3statorCurrentRange
+//                    speedRange = 8500..9500
+//                }
+//
+//                timedTest {
+//                    percentOutput = -0.25
+//                    supplyCurrentRange = volt3supplyCurrentRange
+//                    statorCurrentRange = volt3statorCurrentRange
+//                    speedRange = -9500..-8500
+//                }
+//
+//                timedTest {
+//                    percentOutput = 0.5
+//                    supplyCurrentRange = volt6supplyCurrentRange
+//                    statorCurrentRange = volt6statorCurrentRange
+//                    speedRange = 17200..19500
+//                }
+//
+//                timedTest {
+//                    percentOutput = -0.5
+//                    supplyCurrentRange = volt6supplyCurrentRange
+//                    statorCurrentRange = volt6statorCurrentRange
+//                    speedRange = -19500..-17200
+//                }
+//
+//                timedTest {
+//                    percentOutput = 1.0
+//                    supplyCurrentRange = volt12supplyCurrentRange
+//                    statorCurrentRange = volt12statorCurrentRange
+//                    speedRange = 34750..39500
+//                }
+//
+//                timedTest {
+//                    percentOutput = -1.0
+//                    supplyCurrentRange = volt12supplyCurrentRange
+//                    statorCurrentRange = volt12statorCurrentRange
+//                    speedRange = -39500..-34750
+//                }
+//            }
+//
+//            //Intake Tests
+//            talonCheck {
+//                name = "intake tests"
+//                talons = RobotContainer.INTAKE.talons
+//
+//                val volt6supplycurrentRange = 1.0..4.0
+//
+//                val volt6statorCurrentRange = 1.0..4.0
+//
+//                timedTest {
+//                    percentOutput = 0.5
+//                    supplyCurrentRange = volt6supplycurrentRange
+//                    statorCurrentRange = volt6statorCurrentRange
+//                    speedRange = 3500..4500
+//                }
+//
+//                timedTest {
+//                    percentOutput = -0.5
+//                    supplyCurrentRange = volt6supplycurrentRange
+//                    statorCurrentRange = volt6statorCurrentRange
+//                    speedRange = -4500..-3500
+//                }
+//            }
+//
+//            //Magazine Tests
+//            talonCheck {
+//                name = "magazine tests"
+//                talons = RobotContainer.MAGAZINE.talons
+//
+//                val volt6supplyCurrentRange = 1.0..4.0
+//                val volt12supplyCurrentRange = 13.0..17.0
+//
+//                val volt6statorCurrentRange = 1.0..4.0
+//                val volt12statorCurrentRange = 13.0..17.0
+//
+//                timedTest {
+//                    percentOutput = 0.5
+//                    supplyCurrentRange = volt6supplyCurrentRange
+//                    statorCurrentRange = volt6statorCurrentRange
+//                    speedRange = 2000..3000
+//                }
+//
+//                timedTest {
+//                    percentOutput = -0.5
+//                    supplyCurrentRange = volt6supplyCurrentRange
+//                    statorCurrentRange = volt6statorCurrentRange
+//                    speedRange = -3000..-2000
+//                }
+//
+//                timedTest {
+//                    percentOutput = 1.0
+//                    supplyCurrentRange = volt12supplyCurrentRange
+//                    statorCurrentRange = volt12statorCurrentRange
+//                    speedRange = 3500..5000
+//                }
+//
+//                timedTest {
+//                    percentOutput = -1.0
+//                    supplyCurrentRange = volt12supplyCurrentRange
+//                    statorCurrentRange = volt12statorCurrentRange
+//                    speedRange = -5000..-3500
+//                }
+//            }
+//
+//            //Shooter Tests
+//            talonCheck {
+//                name = "shooter tests"
+//                talons = RobotContainer.SHOOTER.talons
+//
+//                val volt10_000supplyCurrentRange = 1.0..4.0
+//                val volt16_000supplyCurrentRange = 13.0..17.0
+//
+//                val volt10_000statorCurrentRange = 1.0..4.0
+//                val volt16_000statorCurrentRange = 13.0..17.0
+//
+//                followerTimedTest {
+//                    percentOutput = 0.53
+//                    supplyCurrentRange = volt10_000supplyCurrentRange
+//                    statorCurrentRange = volt10_000statorCurrentRange
+//                    speedRange = 8_000..12_000
+//                }
+//
+//                followerTimedTest {
+//                    percentOutput = 0.84
+//                    supplyCurrentRange = volt16_000supplyCurrentRange
+//                    statorCurrentRange = volt16_000statorCurrentRange
+//                    speedRange = 14_000..19_000
+//                }
+//
+//            }
+//
+//            //Turret Tests
+//            talonCheck {
+//                name = "turret tests"
+//                talons = RobotContainer.TURRET.talons
+//
+//                val supplyCurrent = 0.375..1.0
+//                val statorCurrent = 0.375..1.0
+//
+//
+//                positionTalon {
+//                    encoderTarget = 0
+//                    encoderGoodEnough = 100
+//                }
+//
+//                positionTest {
+//                    percentOutput = 0.2
+//                    encoderChangeTarget = 25_000
+//                    encoderGoodEnough = 500
+//                    encoderTimeCount = 500
+//
+//                    supplyCurrentRange = supplyCurrent
+//                    statorCurrentRange = statorCurrent
+//                    speedRange = 550..750
+//                }
+//
+//                positionTest {
+//                    percentOutput = -0.2
+//                    encoderChangeTarget = 25_000
+//                    encoderGoodEnough = 500
+//                    encoderTimeCount = 500
+//
+//                    supplyCurrentRange = supplyCurrent
+//                    statorCurrentRange = statorCurrent
+//                    speedRange = -750..-550
+//                }
+//
+//            }
+//
+//            //Hood Tests
+//            talonCheck {
+//                name = "hood tests"
+//                talons = RobotContainer.HOOD.talons
+//
+//                val supplyCurrent = 0.375..1.0
+//                val statorCurrent = 0.375..1.0
+//
+//                positionTalon {
+//                    encoderTarget = 0
+//                    encoderGoodEnough = 100
+//                }
+//
+//                positionTest {
+//                    percentOutput = 0.2
+//                    encoderChangeTarget = 7000
+//                    encoderGoodEnough = 500
+//                    encoderTimeCount = 500
+//
+//                    supplyCurrentRange = supplyCurrent
+//                    statorCurrentRange = statorCurrent
+//                }
+//
+//                positionTest {
+//                    percentOutput = -0.2
+//                    encoderChangeTarget = 7000
+//                    encoderGoodEnough = 500
+//                    encoderTimeCount = 500
+//
+//                    supplyCurrentRange = supplyCurrent
+//                    statorCurrentRange = statorCurrent
+//                }
+//            }
+//
+//        }
     }
 
     override fun execute() {
-        healthCheck.execute()
+//        healthCheck.execute()
     }
 
-    override fun isFinished() = healthCheck.isFinished()
+    override fun isFinished() = true // healthCheck.isFinished()
 
     override fun end(interrupted: Boolean) {
-        healthCheck.report()
-        RobotContainer.DRIVE.zeroSwerve()
+//        healthCheck.report()
+//        RobotContainer.DRIVE.zeroSwerve()
     }
 }

--- a/src/main/kotlin/frc/robot/commands/HealthCheckCommand.kt
+++ b/src/main/kotlin/frc/robot/commands/HealthCheckCommand.kt
@@ -5,6 +5,7 @@ import frc.robot.RobotContainer
 import mu.KotlinLogging
 import org.strykeforce.healthcheck.HealthCheck
 import org.strykeforce.healthcheck.healthCheck
+import org.strykeforce.swerve.TalonSwerveModule
 
 private val logger = KotlinLogging.logger { }
 
@@ -24,293 +25,300 @@ class HealthCheckCommand : CommandBase() {
     private lateinit var healthCheck: HealthCheck
 
     override fun initialize() {
-//        healthCheck = healthCheck {
-//            //Azimuth Motors
-//            talonCheck {
-//                name = "swerve azimuth tests"
-//                talons = RobotContainer.DRIVE.allWheels.map { it.azimuthTalon }
-//
-//                val volt3supplyCurrentRange = 0.25..0.75
-//                val volt6supplyCurrentRange = 0.5..1.25
-//                val volt9supplyCurrentRange = 1.0..1.5
-//
-//                val volt3statorCurrentRange = 0.25..0.75
-//                val volt6statorCurrentRange = 0.5..1.25
-//                val volt9statorCurrentRange = 1.0..1.5
-//
-//                timedTest {
-//                    percentOutput = 0.25
-//                    supplyCurrentRange = volt3supplyCurrentRange
-//                    statorCurrentRange = volt3statorCurrentRange
-//                    speedRange = 215..250
-//                }
-//
-//                timedTest {
-//                    percentOutput = -0.25
-//                    supplyCurrentRange = volt3supplyCurrentRange
-//                    statorCurrentRange = volt3statorCurrentRange
-//                    speedRange = -250..-215
-//                }
-//
-//                timedTest {
-//                    percentOutput = 0.5
-//                    supplyCurrentRange = volt6supplyCurrentRange
-//                    statorCurrentRange = volt6statorCurrentRange
-//                    speedRange = 475..535
-//                }
-//
-//                timedTest {
-//                    percentOutput = -0.5
-//                    supplyCurrentRange = volt6supplyCurrentRange
-//                    statorCurrentRange = volt6statorCurrentRange
-//                    speedRange = -535..-475
-//                }
-//
-//                timedTest {
-//                    percentOutput = 0.75
-//                    supplyCurrentRange = volt9supplyCurrentRange
-//                    statorCurrentRange = volt9statorCurrentRange
-//                    speedRange = 750..820
-//                }
-//
-//                timedTest {
-//                    percentOutput = -0.75
-//                    supplyCurrentRange = volt9supplyCurrentRange
-//                    statorCurrentRange = volt9statorCurrentRange
-//                    speedRange = -820..-750
-//                }
-//            }
-//
-//            //Drive Motors
-//            talonCheck {
-//                name = "swerve drive tests"
-//                talons = RobotContainer.DRIVE.allWheels.map { it.driveTalon }
-//
-//                val volt3supplyCurrentRange = 0.5..1.125
-//                val volt6supplyCurrentRange = 1.0..2.0
-//                val volt12supplyCurrentRange = 2.5..5.0
-//
-//                val volt3statorCurrentRange = 0.5..1.125
-//                val volt6statorCurrentRange = 1.0..2.0
-//                val volt12statorCurrentRange = 2.5..5.0
-//
-//                timedTest {
-//                    percentOutput = 0.25
-//                    supplyCurrentRange = volt3supplyCurrentRange
-//                    statorCurrentRange = volt3statorCurrentRange
-//                    speedRange = 8500..9500
-//                }
-//
-//                timedTest {
-//                    percentOutput = -0.25
-//                    supplyCurrentRange = volt3supplyCurrentRange
-//                    statorCurrentRange = volt3statorCurrentRange
-//                    speedRange = -9500..-8500
-//                }
-//
-//                timedTest {
-//                    percentOutput = 0.5
-//                    supplyCurrentRange = volt6supplyCurrentRange
-//                    statorCurrentRange = volt6statorCurrentRange
-//                    speedRange = 17200..19500
-//                }
-//
-//                timedTest {
-//                    percentOutput = -0.5
-//                    supplyCurrentRange = volt6supplyCurrentRange
-//                    statorCurrentRange = volt6statorCurrentRange
-//                    speedRange = -19500..-17200
-//                }
-//
-//                timedTest {
-//                    percentOutput = 1.0
-//                    supplyCurrentRange = volt12supplyCurrentRange
-//                    statorCurrentRange = volt12statorCurrentRange
-//                    speedRange = 34750..39500
-//                }
-//
-//                timedTest {
-//                    percentOutput = -1.0
-//                    supplyCurrentRange = volt12supplyCurrentRange
-//                    statorCurrentRange = volt12statorCurrentRange
-//                    speedRange = -39500..-34750
-//                }
-//            }
-//
-//            //Intake Tests
-//            talonCheck {
-//                name = "intake tests"
-//                talons = RobotContainer.INTAKE.talons
-//
-//                val volt6supplycurrentRange = 1.0..4.0
-//
-//                val volt6statorCurrentRange = 1.0..4.0
-//
-//                timedTest {
-//                    percentOutput = 0.5
-//                    supplyCurrentRange = volt6supplycurrentRange
-//                    statorCurrentRange = volt6statorCurrentRange
-//                    speedRange = 3500..4500
-//                }
-//
-//                timedTest {
-//                    percentOutput = -0.5
-//                    supplyCurrentRange = volt6supplycurrentRange
-//                    statorCurrentRange = volt6statorCurrentRange
-//                    speedRange = -4500..-3500
-//                }
-//            }
-//
-//            //Magazine Tests
-//            talonCheck {
-//                name = "magazine tests"
-//                talons = RobotContainer.MAGAZINE.talons
-//
-//                val volt6supplyCurrentRange = 1.0..4.0
-//                val volt12supplyCurrentRange = 13.0..17.0
-//
-//                val volt6statorCurrentRange = 1.0..4.0
-//                val volt12statorCurrentRange = 13.0..17.0
-//
-//                timedTest {
-//                    percentOutput = 0.5
-//                    supplyCurrentRange = volt6supplyCurrentRange
-//                    statorCurrentRange = volt6statorCurrentRange
-//                    speedRange = 2000..3000
-//                }
-//
-//                timedTest {
-//                    percentOutput = -0.5
-//                    supplyCurrentRange = volt6supplyCurrentRange
-//                    statorCurrentRange = volt6statorCurrentRange
-//                    speedRange = -3000..-2000
-//                }
-//
-//                timedTest {
-//                    percentOutput = 1.0
-//                    supplyCurrentRange = volt12supplyCurrentRange
-//                    statorCurrentRange = volt12statorCurrentRange
-//                    speedRange = 3500..5000
-//                }
-//
-//                timedTest {
-//                    percentOutput = -1.0
-//                    supplyCurrentRange = volt12supplyCurrentRange
-//                    statorCurrentRange = volt12statorCurrentRange
-//                    speedRange = -5000..-3500
-//                }
-//            }
-//
-//            //Shooter Tests
-//            talonCheck {
-//                name = "shooter tests"
-//                talons = RobotContainer.SHOOTER.talons
-//
-//                val volt10_000supplyCurrentRange = 1.0..4.0
-//                val volt16_000supplyCurrentRange = 13.0..17.0
-//
-//                val volt10_000statorCurrentRange = 1.0..4.0
-//                val volt16_000statorCurrentRange = 13.0..17.0
-//
-//                followerTimedTest {
-//                    percentOutput = 0.53
-//                    supplyCurrentRange = volt10_000supplyCurrentRange
-//                    statorCurrentRange = volt10_000statorCurrentRange
-//                    speedRange = 8_000..12_000
-//                }
-//
-//                followerTimedTest {
-//                    percentOutput = 0.84
-//                    supplyCurrentRange = volt16_000supplyCurrentRange
-//                    statorCurrentRange = volt16_000statorCurrentRange
-//                    speedRange = 14_000..19_000
-//                }
-//
-//            }
-//
-//            //Turret Tests
-//            talonCheck {
-//                name = "turret tests"
-//                talons = RobotContainer.TURRET.talons
-//
-//                val supplyCurrent = 0.375..1.0
-//                val statorCurrent = 0.375..1.0
-//
-//
-//                positionTalon {
-//                    encoderTarget = 0
-//                    encoderGoodEnough = 100
-//                }
-//
-//                positionTest {
-//                    percentOutput = 0.2
-//                    encoderChangeTarget = 25_000
-//                    encoderGoodEnough = 500
-//                    encoderTimeCount = 500
-//
-//                    supplyCurrentRange = supplyCurrent
-//                    statorCurrentRange = statorCurrent
-//                    speedRange = 550..750
-//                }
-//
-//                positionTest {
-//                    percentOutput = -0.2
-//                    encoderChangeTarget = 25_000
-//                    encoderGoodEnough = 500
-//                    encoderTimeCount = 500
-//
-//                    supplyCurrentRange = supplyCurrent
-//                    statorCurrentRange = statorCurrent
-//                    speedRange = -750..-550
-//                }
-//
-//            }
-//
-//            //Hood Tests
-//            talonCheck {
-//                name = "hood tests"
-//                talons = RobotContainer.HOOD.talons
-//
-//                val supplyCurrent = 0.375..1.0
-//                val statorCurrent = 0.375..1.0
-//
-//                positionTalon {
-//                    encoderTarget = 0
-//                    encoderGoodEnough = 100
-//                }
-//
-//                positionTest {
-//                    percentOutput = 0.2
-//                    encoderChangeTarget = 7000
-//                    encoderGoodEnough = 500
-//                    encoderTimeCount = 500
-//
-//                    supplyCurrentRange = supplyCurrent
-//                    statorCurrentRange = statorCurrent
-//                }
-//
-//                positionTest {
-//                    percentOutput = -0.2
-//                    encoderChangeTarget = 7000
-//                    encoderGoodEnough = 500
-//                    encoderTimeCount = 500
-//
-//                    supplyCurrentRange = supplyCurrent
-//                    statorCurrentRange = statorCurrent
-//                }
-//            }
-//
-//        }
+        healthCheck = healthCheck {
+            //Azimuth Motors
+            talonCheck {
+                name = "swerve azimuth tests"
+                talons = RobotContainer.DRIVE.swerveModules.map {
+                    val module = it as? TalonSwerveModule ?: throw IllegalStateException()
+                    module.azimuthTalon
+                }
+
+                val volt3supplyCurrentRange = 0.25..0.75
+                val volt6supplyCurrentRange = 0.5..1.25
+                val volt9supplyCurrentRange = 1.0..1.5
+
+                val volt3statorCurrentRange = 0.25..0.75
+                val volt6statorCurrentRange = 0.5..1.25
+                val volt9statorCurrentRange = 1.0..1.5
+
+                timedTest {
+                    percentOutput = 0.25
+                    supplyCurrentRange = volt3supplyCurrentRange
+                    statorCurrentRange = volt3statorCurrentRange
+                    speedRange = 215..250
+                }
+
+                timedTest {
+                    percentOutput = -0.25
+                    supplyCurrentRange = volt3supplyCurrentRange
+                    statorCurrentRange = volt3statorCurrentRange
+                    speedRange = -250..-215
+                }
+
+                timedTest {
+                    percentOutput = 0.5
+                    supplyCurrentRange = volt6supplyCurrentRange
+                    statorCurrentRange = volt6statorCurrentRange
+                    speedRange = 475..535
+                }
+
+                timedTest {
+                    percentOutput = -0.5
+                    supplyCurrentRange = volt6supplyCurrentRange
+                    statorCurrentRange = volt6statorCurrentRange
+                    speedRange = -535..-475
+                }
+
+                timedTest {
+                    percentOutput = 0.75
+                    supplyCurrentRange = volt9supplyCurrentRange
+                    statorCurrentRange = volt9statorCurrentRange
+                    speedRange = 750..820
+                }
+
+                timedTest {
+                    percentOutput = -0.75
+                    supplyCurrentRange = volt9supplyCurrentRange
+                    statorCurrentRange = volt9statorCurrentRange
+                    speedRange = -820..-750
+                }
+            }
+
+            //Drive Motors
+            talonCheck {
+                name = "swerve drive tests"
+                talons = RobotContainer.DRIVE.swerveModules.map {
+                    val module = it as? TalonSwerveModule ?: throw IllegalStateException()
+                    module.driveTalon
+                }
+
+                val volt3supplyCurrentRange = 0.5..1.125
+                val volt6supplyCurrentRange = 1.0..2.0
+                val volt12supplyCurrentRange = 2.5..5.0
+
+                val volt3statorCurrentRange = 0.5..1.125
+                val volt6statorCurrentRange = 1.0..2.0
+                val volt12statorCurrentRange = 2.5..5.0
+
+                timedTest {
+                    percentOutput = 0.25
+                    supplyCurrentRange = volt3supplyCurrentRange
+                    statorCurrentRange = volt3statorCurrentRange
+                    speedRange = 8500..9500
+                }
+
+                timedTest {
+                    percentOutput = -0.25
+                    supplyCurrentRange = volt3supplyCurrentRange
+                    statorCurrentRange = volt3statorCurrentRange
+                    speedRange = -9500..-8500
+                }
+
+                timedTest {
+                    percentOutput = 0.5
+                    supplyCurrentRange = volt6supplyCurrentRange
+                    statorCurrentRange = volt6statorCurrentRange
+                    speedRange = 17200..19500
+                }
+
+                timedTest {
+                    percentOutput = -0.5
+                    supplyCurrentRange = volt6supplyCurrentRange
+                    statorCurrentRange = volt6statorCurrentRange
+                    speedRange = -19500..-17200
+                }
+
+                timedTest {
+                    percentOutput = 1.0
+                    supplyCurrentRange = volt12supplyCurrentRange
+                    statorCurrentRange = volt12statorCurrentRange
+                    speedRange = 34750..39500
+                }
+
+                timedTest {
+                    percentOutput = -1.0
+                    supplyCurrentRange = volt12supplyCurrentRange
+                    statorCurrentRange = volt12statorCurrentRange
+                    speedRange = -39500..-34750
+                }
+            }
+
+            //Intake Tests
+            talonCheck {
+                name = "intake tests"
+                talons = RobotContainer.INTAKE.talons
+
+                val volt6supplycurrentRange = 1.0..4.0
+
+                val volt6statorCurrentRange = 1.0..4.0
+
+                timedTest {
+                    percentOutput = 0.5
+                    supplyCurrentRange = volt6supplycurrentRange
+                    statorCurrentRange = volt6statorCurrentRange
+                    speedRange = 3500..4500
+                }
+
+                timedTest {
+                    percentOutput = -0.5
+                    supplyCurrentRange = volt6supplycurrentRange
+                    statorCurrentRange = volt6statorCurrentRange
+                    speedRange = -4500..-3500
+                }
+            }
+
+            //Magazine Tests
+            talonCheck {
+                name = "magazine tests"
+                talons = RobotContainer.MAGAZINE.talons
+
+                val volt6supplyCurrentRange = 1.0..4.0
+                val volt12supplyCurrentRange = 13.0..17.0
+
+                val volt6statorCurrentRange = 1.0..4.0
+                val volt12statorCurrentRange = 13.0..17.0
+
+                timedTest {
+                    percentOutput = 0.5
+                    supplyCurrentRange = volt6supplyCurrentRange
+                    statorCurrentRange = volt6statorCurrentRange
+                    speedRange = 2000..3000
+                }
+
+                timedTest {
+                    percentOutput = -0.5
+                    supplyCurrentRange = volt6supplyCurrentRange
+                    statorCurrentRange = volt6statorCurrentRange
+                    speedRange = -3000..-2000
+                }
+
+                timedTest {
+                    percentOutput = 1.0
+                    supplyCurrentRange = volt12supplyCurrentRange
+                    statorCurrentRange = volt12statorCurrentRange
+                    speedRange = 3500..5000
+                }
+
+                timedTest {
+                    percentOutput = -1.0
+                    supplyCurrentRange = volt12supplyCurrentRange
+                    statorCurrentRange = volt12statorCurrentRange
+                    speedRange = -5000..-3500
+                }
+            }
+
+            //Shooter Tests
+            talonCheck {
+                name = "shooter tests"
+                talons = RobotContainer.SHOOTER.talons
+
+                val volt10_000supplyCurrentRange = 1.0..4.0
+                val volt16_000supplyCurrentRange = 13.0..17.0
+
+                val volt10_000statorCurrentRange = 1.0..4.0
+                val volt16_000statorCurrentRange = 13.0..17.0
+
+                followerTimedTest {
+                    percentOutput = 0.53
+                    supplyCurrentRange = volt10_000supplyCurrentRange
+                    statorCurrentRange = volt10_000statorCurrentRange
+                    speedRange = 8_000..12_000
+                }
+
+                followerTimedTest {
+                    percentOutput = 0.84
+                    supplyCurrentRange = volt16_000supplyCurrentRange
+                    statorCurrentRange = volt16_000statorCurrentRange
+                    speedRange = 14_000..19_000
+                }
+
+            }
+
+            //Turret Tests
+            talonCheck {
+                name = "turret tests"
+                talons = RobotContainer.TURRET.talons
+
+                val supplyCurrent = 0.375..1.0
+                val statorCurrent = 0.375..1.0
+
+
+                positionTalon {
+                    encoderTarget = 0
+                    encoderGoodEnough = 100
+                }
+
+                positionTest {
+                    percentOutput = 0.2
+                    encoderChangeTarget = 25_000
+                    encoderGoodEnough = 500
+                    encoderTimeCount = 500
+
+                    supplyCurrentRange = supplyCurrent
+                    statorCurrentRange = statorCurrent
+                    speedRange = 550..750
+                }
+
+                positionTest {
+                    percentOutput = -0.2
+                    encoderChangeTarget = 25_000
+                    encoderGoodEnough = 500
+                    encoderTimeCount = 500
+
+                    supplyCurrentRange = supplyCurrent
+                    statorCurrentRange = statorCurrent
+                    speedRange = -750..-550
+                }
+
+            }
+
+            //Hood Tests
+            talonCheck {
+                name = "hood tests"
+                talons = RobotContainer.HOOD.talons
+
+                val supplyCurrent = 0.375..1.0
+                val statorCurrent = 0.375..1.0
+
+                positionTalon {
+                    encoderTarget = 0
+                    encoderGoodEnough = 100
+                }
+
+                positionTest {
+                    percentOutput = 0.2
+                    encoderChangeTarget = 7000
+                    encoderGoodEnough = 500
+                    encoderTimeCount = 500
+
+                    supplyCurrentRange = supplyCurrent
+                    statorCurrentRange = statorCurrent
+                }
+
+                positionTest {
+                    percentOutput = -0.2
+                    encoderChangeTarget = 7000
+                    encoderGoodEnough = 500
+                    encoderTimeCount = 500
+
+                    supplyCurrentRange = supplyCurrent
+                    statorCurrentRange = statorCurrent
+                }
+            }
+
+        }
     }
 
     override fun execute() {
-//        healthCheck.execute()
+        healthCheck.execute()
     }
 
-    override fun isFinished() = true // healthCheck.isFinished()
+    override fun isFinished() = healthCheck.isFinished()
 
     override fun end(interrupted: Boolean) {
-//        healthCheck.report()
+        healthCheck.report()
+        // TODO: convert to new swerve
 //        RobotContainer.DRIVE.zeroSwerve()
     }
 }

--- a/vendordeps/thirdcoast.json
+++ b/vendordeps/thirdcoast.json
@@ -1,7 +1,7 @@
 {
     "fileName": "thirdcoast.json",
     "name": "StrykeForce-ThirdCoast",
-    "version": "21.0.0",
+    "version": "21.3.0",
     "uuid": "13c4f4b5-a1c0-4670-8f8d-b7b03628c0d3",
     "mavenUrls": [
         "http://maven.strykeforce.org/repo"
@@ -11,7 +11,7 @@
         {
             "groupId": "org.strykeforce",
             "artifactId": "thirdcoast",
-            "version": "21.0.0"
+            "version": "21.3.0"
         }
     ],
     "jniDependencies": [],


### PR DESCRIPTION
This version of Third Coast now uses the WPILib swerve kinematics, odometry and trajectory math classes. The most significant change is the use of real-world units, for example:

- angles are now represented by Rotation2D objects
- distances are Translation2D objects
- positions are Pose2D objects

These changes for the most part just fix the build - search for `TODO` markers in the source code to complete the conversion.

Closes #105 
